### PR TITLE
feat: implement app typography settings

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,7 +1,7 @@
 import '../global.css';
 
 import { useEffect } from 'react';
-import { Text, View } from 'react-native';
+import { View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaListener } from 'react-native-safe-area-context';
@@ -20,26 +20,9 @@ import { cleanupDeferredBackupZipFiles } from '~/lib/backupExport';
 import { getThemeConfig, DEFAULT_THEME_ID } from '~/lib/theme/themes';
 import { AppLoadingScreen } from '~/components/AppLoadingScreen';
 import { PortalHost } from '~/components/primitives/portal';
+import { Text } from '~/components/ui/text';
 import { Toaster } from '~/components/ui/toast';
-
-// ── Google Fonts ────────────────────────────────────────────────────
-import {
-  Inter_400Regular,
-  Inter_500Medium,
-  Inter_600SemiBold,
-  Inter_700Bold,
-} from '@expo-google-fonts/inter';
-import { Figtree_700Bold } from '@expo-google-fonts/figtree';
-import { Cinzel_700Bold } from '@expo-google-fonts/cinzel';
-import { Merriweather_700Bold } from '@expo-google-fonts/merriweather';
-import { Lora_700Bold } from '@expo-google-fonts/lora';
-import { SpaceMono_700Bold } from '@expo-google-fonts/space-mono';
-import {
-  JetBrainsMono_400Regular,
-  JetBrainsMono_500Medium,
-  JetBrainsMono_600SemiBold,
-  JetBrainsMono_700Bold,
-} from '@expo-google-fonts/jetbrains-mono';
+import { APP_FONT_ASSETS } from '~/lib/theme/fonts';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -72,21 +55,7 @@ export default function Layout() {
   const hasHydrated = useSettingsStore((s) => s._hasHydrated);
   const themeConfig = getThemeConfig(theme);
 
-  const [fontsLoaded, fontsError] = useFonts({
-    Inter_400Regular,
-    Inter_500Medium,
-    Inter_600SemiBold,
-    Inter_700Bold,
-    Figtree_700Bold,
-    Cinzel_700Bold,
-    Merriweather_700Bold,
-    Lora_700Bold,
-    SpaceMono_700Bold,
-    JetBrainsMono_400Regular,
-    JetBrainsMono_500Medium,
-    JetBrainsMono_600SemiBold,
-    JetBrainsMono_700Bold,
-  });
+  const [fontsLoaded, fontsError] = useFonts(APP_FONT_ASSETS);
 
   const [primaryColor, primaryForeground, backgroundColor] = useCSSVariable([
     '--color-primary',

--- a/apps/mobile/src/components/primitives/dialog/index.tsx
+++ b/apps/mobile/src/components/primitives/dialog/index.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { BackHandler, GestureResponderEvent, Pressable, Text, View } from 'react-native';
+import { BackHandler, GestureResponderEvent, Pressable, View } from 'react-native';
 import {
   NavigationContext,
   usePreventRemove,
 } from '@react-navigation/native';
+import { Text } from '~/components/ui/text';
 import type { NavigationProp, ParamListBase } from '@react-navigation/native';
 import { useControllableState } from '~/components/primitives/hooks';
 import { Portal as RNPPortal } from '~/components/primitives/portal';

--- a/apps/mobile/src/components/primitives/label/index.tsx
+++ b/apps/mobile/src/components/primitives/label/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Pressable, Text as RNText } from 'react-native';
+import { Pressable } from 'react-native';
 import * as Slot from '~/components/primitives/slot';
+import { Text as AppText } from '~/components/ui/text';
 import type { RootProps, RootRef, TextProps, TextRef } from './types';
 
 const Root = (props: RootProps & { ref?: React.Ref<RootRef> }) => {
@@ -13,7 +14,7 @@ Root.displayName = 'RootNativeLabel';
 
 const Text = (props: TextProps & { ref?: React.Ref<TextRef> }) => {
   const { asChild, ref, ...rest } = props;
-  const Component = asChild ? Slot.Text : RNText;
+  const Component = asChild ? Slot.Text : AppText;
   return <Component ref={ref} {...rest} />;
 };
 

--- a/apps/mobile/src/components/primitives/toast/index.tsx
+++ b/apps/mobile/src/components/primitives/toast/index.tsx
@@ -1,6 +1,7 @@
 import * as Slot from '~/components/primitives/slot';
 import * as React from 'react';
-import { Pressable, Text, View, type GestureResponderEvent } from 'react-native';
+import { Pressable, View, type GestureResponderEvent } from 'react-native';
+import { Text } from '~/components/ui/text';
 import type {
   ActionProps,
   ActionRef,

--- a/apps/mobile/src/components/ui/dialog.tsx
+++ b/apps/mobile/src/components/ui/dialog.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { Modal, Platform, Text, View, type ViewProps } from 'react-native';
+import { Modal, Platform, View, type ViewProps } from 'react-native';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 import { FullWindowOverlay as RNFullWindowOverlay } from 'react-native-screens';
 import { X } from 'lucide-react-native';
 import { cn } from 'tailwind-variants';
 import * as DialogPrimitive from '~/components/primitives/dialog';
 import { Icon } from '~/components/ui/icon';
+import { Text } from '~/components/ui/text';
 import { NativeOnlyAnimatedView } from '~/components/ui/native-only-animated-view';
 
 type AndroidOverlayStrategy = 'portal' | 'modal';

--- a/apps/mobile/src/components/ui/text.tsx
+++ b/apps/mobile/src/components/ui/text.tsx
@@ -1,7 +1,15 @@
 import * as React from 'react';
-import { Text as RNText, type Role } from 'react-native';
+import { Platform, Text as RNText, type StyleProp, type TextStyle, type Role } from 'react-native';
 import { cn, tv, type VariantProps } from 'tailwind-variants';
 import * as Slot from '~/components/primitives/slot';
+import { useSettingsStore } from '~/lib/settings';
+import {
+  FONT_SIZE_DELTA,
+  getTitleFont,
+  resolveHeadingFontMetrics,
+  resolveTitleFontId,
+  type BodyFontSize,
+} from '~/lib/typography';
 
 const textVariants = tv({
   base: 'text-foreground text-base text-left font-body',
@@ -46,12 +54,117 @@ const ARIA_LEVEL: Partial<Record<TextVariant, string>> = {
   h4: '4',
 };
 
+/**
+ * Variants that receive the heading vertical-metrics fix (lineHeight adjustment).
+ * Kept separate from `usesHeadingFont` because the metrics were tuned for these
+ * specific large font sizes (20–36 px). Ad-hoc `font-heading` usage on smaller
+ * text (e.g. a date label styled with the heading font) should NOT get the
+ * aggressive androidLineHeightScale applied — that inflates their line box and
+ * makes pill-shaped buttons visually taller on Android than on iOS.
+ */
+const HEADING_VARIANTS = new Set<TextVariant>(['h1', 'h2', 'h3', 'h4']);
+
+/**
+ * Resolved base font sizes (px) for each Tailwind text-* class used
+ * by the variants, assuming the default 16 px rem.
+ *
+ * The "Default" body font size setting leaves these unchanged.
+ * "Small" / "Large" adds a ±2 px delta.  React Native's `allowFontScaling`
+ * (which is `true` by default) still applies the phone's system font scale
+ * on top, so the user's accessibility preferences are respected.
+ */
+const VARIANT_BASE_SIZE: Partial<Record<TextVariant, number>> = {
+  default: 16, // text-base
+  p: 16,
+  blockquote: 16,
+  code: 14, // text-sm
+  lead: 20, // text-xl
+  large: 18, // text-lg
+  small: 14, // text-sm
+  muted: 14, // text-sm
+};
+
+/**
+ * Maps standard Tailwind text-size class suffixes to their px value.
+ * Used to detect when a className overrides the variant's default size
+ * (e.g. `<Text className="text-xs">` on the default variant).
+ */
+const TEXT_SIZE_PX: Record<string, number> = {
+  xs: 12,
+  sm: 14,
+  base: 16,
+  lg: 18,
+  xl: 20,
+  '2xl': 24,
+  '3xl': 30,
+  '4xl': 36,
+};
+
+// Matches both named sizes (text-sm, text-2xl …) and arbitrary px values
+// (text-[10px], text-[13.5px]). Groups: [1] named suffix, [2] arbitrary px number.
+// Note: \b is placed after named suffixes only; the closing ] already terminates
+// an arbitrary match unambiguously so no trailing boundary is needed there.
+const TEXT_SIZE_RE = /\btext-(?:(xs|sm|base|lg|xl|[2-9]xl)\b|\[([0-9]+(?:\.[0-9]+)?)px\])/g;
+const HEADING_FONT_RE = /\bfont-heading\b/;
+
+function getLastTextSizePx(classes?: string): number | undefined {
+  if (!classes) return undefined;
+
+  let resolvedSize: number | undefined;
+  for (const match of classes.matchAll(TEXT_SIZE_RE)) {
+    if (match[1]) {
+      resolvedSize = TEXT_SIZE_PX[match[1]] ?? resolvedSize;
+    } else if (match[2]) {
+      resolvedSize = parseFloat(match[2]);
+    }
+  }
+  return resolvedSize;
+}
+
+/**
+ * Resolve the actual base font-size for a Text component by checking:
+ * 1. Explicit text-size class in `className` (wins)
+ * 2. Explicit text-size class in `textClass`
+ * 3. Explicit text-size class in the resolved variant classes
+ * 4. Variant's known base size
+ * 3. Fallback 16 px
+ */
+function resolveBaseSize(
+  variant: TextVariant,
+  variantClasses: string,
+  className?: string,
+  textClass?: string,
+): number {
+  for (const cls of [className, textClass, variantClasses]) {
+    const size = getLastTextSizePx(cls);
+    if (size) return size;
+  }
+  return VARIANT_BASE_SIZE[variant] ?? 16;
+}
+
+function usesHeadingFont(
+  variantClasses: string,
+  className?: string,
+  textClass?: string,
+): boolean {
+  return [className, textClass, variantClasses].some(
+    (classes) => !!classes && HEADING_FONT_RE.test(classes),
+  );
+}
+
+/** Return the px delta for body text. Memoised selector avoids unnecessary re-renders. */
+function useBodyFontDelta(): number {
+  const bodyFontSize: BodyFontSize = useSettingsStore((s) => s.bodyFontSize);
+  return FONT_SIZE_DELTA[bodyFontSize];
+}
+
 const TextClassContext = React.createContext<string | undefined>(undefined);
 
 function Text({
   className,
   asChild = false,
   variant = 'default',
+  style,
   ref,
   ...props
 }: React.ComponentProps<typeof RNText> &
@@ -60,13 +173,80 @@ function Text({
   }) {
   const textClass = React.useContext(TextClassContext);
   const Component = asChild ? Slot.Text : RNText;
+  const variantClasses = textVariants({ variant });
+
+  const delta = useBodyFontDelta();
+  const themeId = useSettingsStore((s) => s.theme);
+  const titleFontId = useSettingsStore((s) => s.titleFont);
+  const effectiveVariant = variant ?? 'default';
+  // Any text carrying font-heading skips body-size scaling (it already has its
+  // own font choice and scaling it would be surprising).
+  const isHeadingStyled = usesHeadingFont(variantClasses, className, textClass);
+  // Only the canonical h1–h4 variants get the lineHeight/metrics fix — the
+  // per-font scales were measured at heading sizes (20–36 px).
+  const isVariantHeading = HEADING_VARIANTS.has(effectiveVariant);
+
+  let mergedStyle: StyleProp<TextStyle> = style;
+
+  // Body text font-size adjustment (±2 px)
+  if (delta !== 0 && !isHeadingStyled) {
+    const base = resolveBaseSize(effectiveVariant, variantClasses, className, textClass);
+    mergedStyle = [{ fontSize: base + delta }, style];
+  }
+
+  // ── Heading vertical-metrics fix ────────────────────────────────────────
+  //
+  // ROOT CAUSE (Android only)
+  // React Native's ReactTextView draws glyphs into a canvas whose height is
+  // determined by `lineHeight`. Any part of a glyph that falls outside that
+  // canvas is hard-clipped by the Android view system — `paddingBottom` and
+  // `overflow: visible` on parent views have NO effect on this.
+  // iOS uses Core Text which respects the font's own vertical metrics, so
+  // glyphs are almost never clipped there.
+  //
+  // FIX
+  // Set `lineHeight` tall enough to contain the font's full glyph extent.
+  // Only applied to h1–h4 variants: the per-font scales were measured at
+  // heading sizes and would over-inflate smaller ad-hoc heading-font text.
+  if (isVariantHeading) {
+    const fontConfig = getTitleFont(resolveTitleFontId(themeId, titleFontId));
+    const headingSize = resolveBaseSize(effectiveVariant, variantClasses, className, textClass);
+    const resolvedMetrics = resolveHeadingFontMetrics(fontConfig.fontFamily, headingSize);
+
+    if (Platform.OS === 'android') {
+      // Android can clip deep descenders inside TextView unless lineHeight
+      // is expanded; parent padding/overflow cannot fix this draw-canvas limit.
+      mergedStyle = [
+        {
+          includeFontPadding: true,
+          ...(resolvedMetrics
+            ? {
+                lineHeight: resolvedMetrics.lineHeight,
+                marginBottom: 0,
+              }
+            : undefined),
+        },
+        style,
+      ];
+    } else if (resolvedMetrics) {
+      // iOS handles descenders fine — only apply font-specific overrides
+      mergedStyle = [
+        {
+          lineHeight: resolvedMetrics.lineHeight,
+          marginBottom: resolvedMetrics.bottomTrim,
+        },
+        style,
+      ];
+    }
+  }
 
   return (
     <Component
       ref={ref}
-      className={cn(textVariants({ variant }), textClass, className)}
+      className={cn(variantClasses, textClass, className)}
       role={variant ? ROLE[variant] : undefined}
       aria-level={variant ? ARIA_LEVEL[variant] : undefined}
+      style={mergedStyle}
       {...props}
     />
   );

--- a/apps/mobile/src/components/ui/text.tsx
+++ b/apps/mobile/src/components/ui/text.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { Platform, Text as RNText, type StyleProp, type TextStyle, type Role } from 'react-native';
+import {
+  Platform,
+  Text as RNText,
+  type StyleProp,
+  type TextStyle,
+  type Role,
+} from 'react-native';
 import { cn, tv, type VariantProps } from 'tailwind-variants';
 import * as Slot from '~/components/primitives/slot';
 import { useSettingsStore } from '~/lib/settings';
@@ -9,7 +15,7 @@ import {
   resolveHeadingFontMetrics,
   resolveTitleFontId,
   type BodyFontSize,
-} from '~/lib/typography';
+} from '~/lib/theme/typography';
 
 const textVariants = tv({
   base: 'text-foreground text-base text-left font-body',
@@ -104,7 +110,8 @@ const TEXT_SIZE_PX: Record<string, number> = {
 // (text-[10px], text-[13.5px]). Groups: [1] named suffix, [2] arbitrary px number.
 // Note: \b is placed after named suffixes only; the closing ] already terminates
 // an arbitrary match unambiguously so no trailing boundary is needed there.
-const TEXT_SIZE_RE = /\btext-(?:(xs|sm|base|lg|xl|[2-9]xl)\b|\[([0-9]+(?:\.[0-9]+)?)px\])/g;
+const TEXT_SIZE_RE =
+  /\btext-(?:(xs|sm|base|lg|xl|[2-9]xl)\b|\[([0-9]+(?:\.[0-9]+)?)px\])/g;
 const HEADING_FONT_RE = /\bfont-heading\b/;
 
 function getLastTextSizePx(classes?: string): number | undefined {
@@ -210,7 +217,12 @@ function Text({
   // heading sizes and would over-inflate smaller ad-hoc heading-font text.
   if (isVariantHeading) {
     const fontConfig = getTitleFont(resolveTitleFontId(themeId, titleFontId));
-    const headingSize = resolveBaseSize(effectiveVariant, variantClasses, className, textClass);
+    const headingSize = resolveBaseSize(
+      effectiveVariant,
+      variantClasses,
+      className,
+      textClass,
+    );
     const resolvedMetrics = resolveHeadingFontMetrics(fontConfig.fontFamily, headingSize);
 
     if (Platform.OS === 'android') {

--- a/apps/mobile/src/constants.ts
+++ b/apps/mobile/src/constants.ts
@@ -27,6 +27,7 @@ export const SHEET_NAMES = {
   WORKSHEET_TEMPLATE: 'worksheet-template-sheet',
   THEME_PICKER: 'theme-picker-sheet',
   JOURNAL_FOCUS_AREAS: 'journal-focus-areas-sheet',
+  FONT_PICKER: 'font-picker-sheet',
 } as const;
 
 /*

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -257,6 +257,18 @@ export const ar: Translations = {
   'Set the first day of the week in the calendar view':
     'حدد أول يوم في الأسبوع في عرض التقويم',
 
+  // Settings - Typography
+  Typography: 'الخطوط',
+  'Title Font': 'خط العنوان',
+  'Choose a font for titles and headings': 'اختر خطًا للعناوين والترويسات',
+  Default: 'افتراضي',
+  'Font Size': 'حجم الخط',
+  'Adjust the size of body text': 'ضبط حجم النص الأساسي',
+  Small: 'صغير',
+  Large: 'كبير',
+  'Preview of the selected font': 'معاينة الخط المحدد',
+  'Gratitude makes today brighter': 'الامتنان يجعل اليوم أكثر إشراقًا',
+
   // Settings - Journaling
   Journaling: 'الكتابة اليومية',
   'Worksheet Template': 'قالب ورقة الكتابة',
@@ -291,7 +303,7 @@ export const ar: Translations = {
   'Lock with biometric scanner if supported':
     'يمكن لتاكبوك القفل باستخدام الماسح البيومتري لجهازك (إذا كان مدعوماً)',
 
-    // Settings - Backup & Restore
+  // Settings - Backup & Restore
   'Backup & Restore': 'النسخ الاحتياطي والاستعادة',
   'Google Drive Backup': 'نسخ احتياطي على Google Drive',
   'Automatically back up your entries with Google Drive':
@@ -346,7 +358,8 @@ export const ar: Translations = {
     'جاري إضافة الوسوم والمطالبات قبل استعادة الإدخالات.',
   'Processing {processed} of {total} journal entries and attached media.':
     'جاري معالجة {processed} من {total} من إدخالات اليوميات والوسائط المرفقة.',
-  'No journal entries found in this backup.': 'لم يتم العثور على إدخالات يوميات في هذه النسخة الاحتياطية.',
+  'No journal entries found in this backup.':
+    'لم يتم العثور على إدخالات يوميات في هذه النسخة الاحتياطية.',
   'Refreshing your journal so imported data appears everywhere.':
     'جاري تحديث يومياتك حتى تظهر البيانات المستوردة في كل مكان.',
   'Entries processed': 'الإدخالات المعالجة',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -272,6 +272,18 @@ export const en = {
   'Set the first day of the week in the calendar view':
     'Set the first day of the week in the calendar view',
 
+  // Settings - Typography
+  Typography: 'Typography',
+  'Title Font': 'Title Font',
+  'Choose a font for titles and headings': 'Choose a font for titles and headings',
+  Default: 'Default',
+  'Font Size': 'Font Size',
+  'Adjust the size of body text': 'Adjust the size of body text',
+  Small: 'Small',
+  Large: 'Large',
+  'Preview of the selected font': 'Preview of the selected font',
+  'Gratitude makes today brighter': 'Gratitude makes today brighter',
+
   // Settings - Journaling
   Journaling: 'Journaling',
   'Worksheet Template': 'Worksheet Template',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -259,6 +259,18 @@ export const he: Translations = {
   'Set the first day of the week in the calendar view':
     'הגדר את היום הראשון בשבוע בתצוגת היומן',
 
+  // Settings - Typography
+  Typography: 'טיפוגרפיה',
+  'Title Font': 'גופן כותרת',
+  'Choose a font for titles and headings': 'בחר גופן עבור כותרות וכותרות משנה',
+  Default: 'ברירת מחדל',
+  'Font Size': 'גודל גופן',
+  'Adjust the size of body text': 'התאם את גודל טקסט הגוף',
+  Small: 'קטן',
+  Large: 'גדול',
+  'Preview of the selected font': 'תצוגה מקדימה של הגופן הנבחר',
+  'Gratitude makes today brighter': 'הכרת תודה הופכת את היום לבהיר יותר',
+
   // Settings - Journaling
   Journaling: 'כתיבה יומית',
   'Worksheet Template': 'תבנית דף כתיבה',
@@ -293,7 +305,7 @@ export const he: Translations = {
   'Lock with biometric scanner if supported':
     'טאקבוק יכול לנעול באמצעות הסורק הביומטרי של המכשיר (אם נתמך)',
 
-    // Settings - Backup & Restore
+  // Settings - Backup & Restore
   'Backup & Restore': 'גיבוי ושחזור',
   'Google Drive Backup': 'גיבוי ל-Google Drive',
   'Automatically back up your entries with Google Drive':
@@ -340,8 +352,7 @@ export const he: Translations = {
   'Restore entries and media': 'משחזר רשומות ומדיה',
   'Refresh journal data': 'מרענן נתוני יומן',
   'Loading the selected import file.': 'טוען את קובץ הייבוא שנבחר.',
-  'Checking backup contents and file structure.':
-    'בודק את תוכן הגיבוי ומבנה הקובץ.',
+  'Checking backup contents and file structure.': 'בודק את תוכן הגיבוי ומבנה הקובץ.',
   'Restoring profile details and profile photo if available.':
     'משחזר פרטי פרופיל ותמונת פרופיל במידה וזמינה.',
   'Adding tags and prompts before entries are restored.':

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -252,6 +252,18 @@ export const zhCN: Translations = {
   'First Day of Week': '一周的第一天',
   'Set the first day of the week in the calendar view': '设置日历视图中一周的第一天',
 
+  // Settings - Typography
+  Typography: '排版',
+  'Title Font': '标题字体',
+  'Choose a font for titles and headings': '为标题和副标题选择字体',
+  Default: '默认',
+  'Font Size': '字体大小',
+  'Adjust the size of body text': '调整正文字体大小',
+  Small: '小',
+  Large: '大',
+  'Preview of the selected font': '所选字体的预览',
+  'Gratitude makes today brighter': '感恩让今天更明亮',
+
   // Settings - Journaling
   Journaling: '日记书写',
   'Worksheet Template': '写作模板',
@@ -285,7 +297,7 @@ export const zhCN: Translations = {
   'Lock with biometric scanner if supported':
     '塔克博克可使用设备的生物识别扫描仪锁定（如果设备支持）',
 
-    // Settings - Backup & Restore
+  // Settings - Backup & Restore
   'Backup & Restore': '备份与恢复',
   'Google Drive Backup': 'Google Drive 备份',
   'Automatically back up your entries with Google Drive':
@@ -301,8 +313,7 @@ export const zhCN: Translations = {
   'Restore your data from a .zip file': '从 .zip 文件恢复您的数据',
   'Import from Gratitude App': '从 Gratitude 应用导入',
   'Importing from Gratitude App': '正在从 Gratitude 应用导入',
-  'Import data from a Gratitude App .zip backup':
-    '从 Gratitude 应用的 .zip 备份导入数据',
+  'Import data from a Gratitude App .zip backup': '从 Gratitude 应用的 .zip 备份导入数据',
   'Choose Import Mode': '选择导入模式',
   'How should this import handle entries that already exist in Tackbok?':
     '本次导入应如何处理 Tackbok 中已存在的条目？',
@@ -310,11 +321,9 @@ export const zhCN: Translations = {
   'Skip Existing Entries (Recommended)': '跳过现有条目（推荐）',
   'Only import entries with new note IDs': '仅导入具有新笔记 ID 的条目',
   'Overwrite Matching Entries': '覆盖匹配的条目',
-  'Replace existing entries when note IDs match':
-    '当笔记 ID 匹配时替换现有条目',
+  'Replace existing entries when note IDs match': '当笔记 ID 匹配时替换现有条目',
   'Import from Presently App': '从 Presently 应用导入',
-  'Restore your data from a Presently .csv file':
-    '从 Presently 的 .csv 文件恢复您的数据',
+  'Restore your data from a Presently .csv file': '从 Presently 的 .csv 文件恢复您的数据',
   'Import from Presently?': '从 Presently 导入？',
   'This will import entries from a Presently app CSV file. Duplicate entries will be skipped.':
     '这将从 Presently 应用的 CSV 文件导入条目。重复的条目将被跳过。',
@@ -332,8 +341,7 @@ export const zhCN: Translations = {
   'Restore entries and media': '恢复条目和媒体',
   'Refresh journal data': '刷新日记数据',
   'Loading the selected import file.': '正在加载选定的导入文件。',
-  'Checking backup contents and file structure.':
-    '正在检查备份内容和文件结构。',
+  'Checking backup contents and file structure.': '正在检查备份内容和文件结构。',
   'Restoring profile details and profile photo if available.':
     '正在恢复个人资料详情和头像（如果有）。',
   'Adding tags and prompts before entries are restored.':

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -253,6 +253,18 @@ export const zhTW: Translations = {
   'First Day of Week': '每週的第一天',
   'Set the first day of the week in the calendar view': '設定日曆視圖中每週的第一天',
 
+  // Settings - Typography
+  Typography: '排版',
+  'Title Font': '標題字型',
+  'Choose a font for titles and headings': '為標題和副標題選擇字型',
+  Default: '預設',
+  'Font Size': '字型大小',
+  'Adjust the size of body text': '調整正文字型大小',
+  Small: '小',
+  Large: '大',
+  'Preview of the selected font': '所選字型的預覽',
+  'Gratitude makes today brighter': '感恩讓今天更明亮',
+
   // Settings - Journaling
   Journaling: '日記書寫',
   'Worksheet Template': '寫作模板',
@@ -285,7 +297,7 @@ export const zhTW: Translations = {
   'Unlock Tackbok': '解鎖塔克博克',
   'Lock with biometric scanner if supported': '若裝置支援，使用生物辨識鎖定',
 
-    // Settings - Backup & Restore
+  // Settings - Backup & Restore
   'Backup & Restore': '備份與還原',
   'Google Drive Backup': 'Google Drive 備份',
   'Automatically back up your entries with Google Drive':
@@ -310,11 +322,9 @@ export const zhTW: Translations = {
   'Skip Existing Entries (Recommended)': '略過現有紀錄（推薦）',
   'Only import entries with new note IDs': '僅匯入具有新筆記 ID 的紀錄',
   'Overwrite Matching Entries': '覆寫配對的紀錄',
-  'Replace existing entries when note IDs match':
-    '當筆記 ID 相符時取代現有紀錄',
+  'Replace existing entries when note IDs match': '當筆記 ID 相符時取代現有紀錄',
   'Import from Presently App': '從 Presently 應用程式匯入',
-  'Restore your data from a Presently .csv file':
-    '從 Presently 的 .csv 檔案還原您的資料',
+  'Restore your data from a Presently .csv file': '從 Presently 的 .csv 檔案還原您的資料',
   'Import from Presently?': '從 Presently 匯入？',
   'This will import entries from a Presently app CSV file. Duplicate entries will be skipped.':
     '這將從 Presently 應用程式的 CSV 檔案匯入紀錄。重複的紀錄將被略過。',
@@ -332,8 +342,7 @@ export const zhTW: Translations = {
   'Restore entries and media': '還原紀錄和媒體',
   'Refresh journal data': '重整日記資料',
   'Loading the selected import file.': '正在載入選定的匯入檔案。',
-  'Checking backup contents and file structure.':
-    '正在檢查備份內容和檔案結構。',
+  'Checking backup contents and file structure.': '正在檢查備份內容和檔案結構。',
   'Restoring profile details and profile photo if available.':
     '正在還原個人檔案詳細資料和頭像（如果有）。',
   'Adding tags and prompts before entries are restored.':

--- a/apps/mobile/src/lib/settings/store.ts
+++ b/apps/mobile/src/lib/settings/store.ts
@@ -5,6 +5,13 @@ import { Uniwind } from 'uniwind';
 import { FirstDay, type FirstDayOfWeek } from '~/types';
 import { DEFAULT_THEME_ID, getThemeConfig } from '~/lib/theme';
 import {
+  applyTitleFont,
+  DEFAULT_TITLE_FONT_SELECTION,
+  normalizeTitleFontSelection,
+  type BodyFontSize,
+  type TitleFontSelection,
+} from '~/lib/typography';
+import {
   DEFAULT_JOURNAL_FOCUS_AREAS,
   type BuiltInJournalPromptCategoryId,
   type JournalPromptsMode,
@@ -30,6 +37,10 @@ interface SettingsState {
   dateIncludesDayOfWeek: boolean;
   firstDayOfWeek: FirstDayOfWeek;
   showTimelineBorders: boolean;
+
+  // Typography
+  titleFont: TitleFontSelection;
+  bodyFontSize: BodyFontSize;
 
   // Security
   biometricUnlockEnabled: boolean;
@@ -61,6 +72,8 @@ interface SettingsState {
   setDateIncludesDayOfWeek: (enabled: boolean) => void;
   setFirstDayOfWeek: (day: FirstDayOfWeek) => void;
   setShowTimelineBorders: (enabled: boolean) => void;
+  setTitleFont: (fontId: TitleFontSelection) => void;
+  setBodyFontSize: (size: BodyFontSize) => void;
   setBiometricUnlockEnabled: (enabled: boolean) => void;
   setGoogleDriveBackupEnabled: (enabled: boolean) => void;
   setBackupFrequency: (frequency: 'daily' | 'weekly' | 'on_change') => void;
@@ -74,7 +87,7 @@ interface SettingsState {
 
 export const useSettingsStore = create<SettingsState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       // Default values
       dailyReminderEnabled: false,
       reminderTime: '09:00',
@@ -87,6 +100,8 @@ export const useSettingsStore = create<SettingsState>()(
       dateIncludesDayOfWeek: false,
       firstDayOfWeek: FirstDay.MONDAY,
       showTimelineBorders: false,
+      titleFont: DEFAULT_TITLE_FONT_SELECTION,
+      bodyFontSize: 'default',
       biometricUnlockEnabled: false,
       googleDriveBackupEnabled: false,
       backupFrequency: 'daily',
@@ -108,6 +123,7 @@ export const useSettingsStore = create<SettingsState>()(
       setTheme: (theme) => {
         const id = getThemeConfig(theme).id;
         Uniwind.setTheme(id);
+        applyTitleFont(id, get().titleFont);
         set({ theme: id });
       },
       setTimelineEntryLength: (length) => {
@@ -119,6 +135,12 @@ export const useSettingsStore = create<SettingsState>()(
       setDateIncludesDayOfWeek: (enabled) => set({ dateIncludesDayOfWeek: enabled }),
       setFirstDayOfWeek: (day) => set({ firstDayOfWeek: day }),
       setShowTimelineBorders: (enabled) => set({ showTimelineBorders: enabled }),
+      setTitleFont: (fontId) => {
+        const safeFontId = normalizeTitleFontSelection(fontId);
+        applyTitleFont(getThemeConfig(get().theme).id, safeFontId);
+        set({ titleFont: safeFontId });
+      },
+      setBodyFontSize: (size) => set({ bodyFontSize: size }),
       setBiometricUnlockEnabled: (enabled) => set({ biometricUnlockEnabled: enabled }),
       setGoogleDriveBackupEnabled: (enabled) =>
         set({ googleDriveBackupEnabled: enabled }),
@@ -137,12 +159,17 @@ export const useSettingsStore = create<SettingsState>()(
       onRehydrateStorage: () => (state) => {
         if (state) {
           state.setHasHydrated(true);
-          // If the persisted theme is no longer valid (e.g., 'default'), map it.
-          // Use setTheme (not direct mutation): a partial set above replaces the store
-          // object, so mutating this callback's `state` would not update subscribers
-          // or persist; setTheme also keeps Uniwind in sync.
           const safeThemeId = getThemeConfig(state.theme).id;
-          state.setTheme(safeThemeId);
+          const safeTitleFont = normalizeTitleFontSelection(state.titleFont);
+          Uniwind.setTheme(safeThemeId);
+          if (state.theme !== safeThemeId || state.titleFont !== safeTitleFont) {
+            useSettingsStore.setState({
+              theme: safeThemeId,
+              titleFont: safeTitleFont,
+            });
+          }
+
+          applyTitleFont(safeThemeId, safeTitleFont);
         } else {
           console.warn('Settings store rehydration failed');
           // `state` is unavailable here (persisted merge failed), so we cannot call
@@ -162,6 +189,8 @@ export const useSettingsStore = create<SettingsState>()(
         dateIncludesDayOfWeek: state.dateIncludesDayOfWeek,
         firstDayOfWeek: state.firstDayOfWeek,
         showTimelineBorders: state.showTimelineBorders,
+        titleFont: state.titleFont,
+        bodyFontSize: state.bodyFontSize,
         biometricUnlockEnabled: state.biometricUnlockEnabled,
         googleDriveBackupEnabled: state.googleDriveBackupEnabled,
         backupFrequency: state.backupFrequency,

--- a/apps/mobile/src/lib/settings/store.ts
+++ b/apps/mobile/src/lib/settings/store.ts
@@ -6,11 +6,13 @@ import { FirstDay, type FirstDayOfWeek } from '~/types';
 import { DEFAULT_THEME_ID, getThemeConfig } from '~/lib/theme';
 import {
   applyTitleFont,
+  DEFAULT_BODY_FONT_SIZE,
   DEFAULT_TITLE_FONT_SELECTION,
+  normalizeBodyFontSize,
   normalizeTitleFontSelection,
   type BodyFontSize,
   type TitleFontSelection,
-} from '~/lib/typography';
+} from '~/lib/theme/typography';
 import {
   DEFAULT_JOURNAL_FOCUS_AREAS,
   type BuiltInJournalPromptCategoryId,
@@ -101,7 +103,7 @@ export const useSettingsStore = create<SettingsState>()(
       firstDayOfWeek: FirstDay.MONDAY,
       showTimelineBorders: false,
       titleFont: DEFAULT_TITLE_FONT_SELECTION,
-      bodyFontSize: 'default',
+      bodyFontSize: DEFAULT_BODY_FONT_SIZE,
       biometricUnlockEnabled: false,
       googleDriveBackupEnabled: false,
       backupFrequency: 'daily',
@@ -114,8 +116,7 @@ export const useSettingsStore = create<SettingsState>()(
       // Actions
       setDailyReminderEnabled: (enabled) => set({ dailyReminderEnabled: enabled }),
       setReminderTime: (time) => set({ reminderTime: time }),
-      setProfileName: (name) =>
-        set({ profileName: name?.trim() ? name.trim() : null }),
+      setProfileName: (name) => set({ profileName: name?.trim() ? name.trim() : null }),
       setProfileEmail: (email) =>
         set({ profileEmail: email?.trim() ? email.trim() : null }),
       setProfileImageUri: (uri) =>
@@ -123,7 +124,7 @@ export const useSettingsStore = create<SettingsState>()(
       setTheme: (theme) => {
         const id = getThemeConfig(theme).id;
         Uniwind.setTheme(id);
-        applyTitleFont(id, get().titleFont);
+        applyTitleFont(get().titleFont);
         set({ theme: id });
       },
       setTimelineEntryLength: (length) => {
@@ -137,10 +138,10 @@ export const useSettingsStore = create<SettingsState>()(
       setShowTimelineBorders: (enabled) => set({ showTimelineBorders: enabled }),
       setTitleFont: (fontId) => {
         const safeFontId = normalizeTitleFontSelection(fontId);
-        applyTitleFont(getThemeConfig(get().theme).id, safeFontId);
+        applyTitleFont(safeFontId);
         set({ titleFont: safeFontId });
       },
-      setBodyFontSize: (size) => set({ bodyFontSize: size }),
+      setBodyFontSize: (size) => set({ bodyFontSize: normalizeBodyFontSize(size) }),
       setBiometricUnlockEnabled: (enabled) => set({ biometricUnlockEnabled: enabled }),
       setGoogleDriveBackupEnabled: (enabled) =>
         set({ googleDriveBackupEnabled: enabled }),
@@ -161,15 +162,21 @@ export const useSettingsStore = create<SettingsState>()(
           state.setHasHydrated(true);
           const safeThemeId = getThemeConfig(state.theme).id;
           const safeTitleFont = normalizeTitleFontSelection(state.titleFont);
+          const safeBodyFontSize = normalizeBodyFontSize(state.bodyFontSize);
           Uniwind.setTheme(safeThemeId);
-          if (state.theme !== safeThemeId || state.titleFont !== safeTitleFont) {
+          if (
+            state.theme !== safeThemeId ||
+            state.titleFont !== safeTitleFont ||
+            state.bodyFontSize !== safeBodyFontSize
+          ) {
             useSettingsStore.setState({
               theme: safeThemeId,
               titleFont: safeTitleFont,
+              bodyFontSize: safeBodyFontSize,
             });
           }
 
-          applyTitleFont(safeThemeId, safeTitleFont);
+          applyTitleFont(safeTitleFont);
         } else {
           console.warn('Settings store rehydration failed');
           // `state` is unavailable here (persisted merge failed), so we cannot call

--- a/apps/mobile/src/lib/theme/typography.ts
+++ b/apps/mobile/src/lib/theme/typography.ts
@@ -1,11 +1,6 @@
 import { Platform, type TextStyle } from 'react-native';
 import { Uniwind } from 'uniwind';
-import {
-  DEFAULT_TITLE_FONT,
-  THEMES,
-  TITLE_FONTS,
-  type TitleFontId,
-} from './theme/registry';
+import { DEFAULT_TITLE_FONT, THEMES, TITLE_FONTS, type TitleFontId } from './registry';
 
 export { DEFAULT_TITLE_FONT, TITLE_FONTS, type TitleFontId };
 export const DEFAULT_TITLE_FONT_SELECTION = 'default' as const;
@@ -14,6 +9,7 @@ export type TitleFontSelection = TitleFontId | typeof DEFAULT_TITLE_FONT_SELECTI
 // ── Body Font Size ─────────────────────────────────────────────────
 export const BODY_FONT_SIZES = ['small', 'default', 'large'] as const;
 export type BodyFontSize = (typeof BODY_FONT_SIZES)[number];
+export const DEFAULT_BODY_FONT_SIZE = 'default' as const;
 
 /**
  * Pixel offset applied to every body-text font size.
@@ -121,9 +117,17 @@ export function normalizeTitleFontSelection(
   return isKnownTitleFontId(fontId) ? fontId : DEFAULT_TITLE_FONT_SELECTION;
 }
 
+/** Coerce persisted or user-provided input into a safe body-font-size value. */
+export function normalizeBodyFontSize(size: string | null | undefined): BodyFontSize {
+  return BODY_FONT_SIZES.includes(size as BodyFontSize)
+    ? (size as BodyFontSize)
+    : DEFAULT_BODY_FONT_SIZE;
+}
 /** Return the built-in title font ID for a given theme. */
 export function getThemeDefaultTitleFontId(themeId: string): TitleFontId {
-  return THEMES.find((theme) => theme.id === themeId)?.defaultTitleFontId ?? DEFAULT_TITLE_FONT;
+  return (
+    THEMES.find((theme) => theme.id === themeId)?.defaultTitleFontId ?? DEFAULT_TITLE_FONT
+  );
 }
 
 /** Resolve a title-font selection to the concrete font ID that should be rendered. */
@@ -169,7 +173,10 @@ export function resolveHeadingFontMetrics(
  * Build a `TextStyle` suitable for rendering a font preview at the given size.
  * Includes heading font metrics (lineHeight) when available.
  */
-export function getTitleFontPreviewStyle(fontFamily: string, fontSize: number): TextStyle {
+export function getTitleFontPreviewStyle(
+  fontFamily: string,
+  fontSize: number,
+): TextStyle {
   const resolvedMetrics = resolveHeadingFontMetrics(fontFamily, fontSize);
 
   return {
@@ -184,15 +191,30 @@ export function getTitleFontPreviewStyle(fontFamily: string, fontSize: number): 
  * This should be called when the font setting changes *and* on app boot
  * (after store hydration).
  */
-export function applyTitleFont(themeId: string, fontId: string | null | undefined) {
-  const font = getTitleFont(resolveTitleFontId(themeId, fontId));
+export function applyTitleFont(fontId: string | null | undefined) {
+  // Update every theme variant, not just the active one, because the app can
+  // render non-active themes at the same time via ScopedTheme previews.
+  if (isDefaultTitleFontSelection(normalizeTitleFontSelection(fontId))) {
+    // "default" selection: each theme uses its own curated heading font, so
+    // resolve the font per-theme inside the loop.
+    for (const theme of THEMES) {
+      const font = getTitleFont(resolveTitleFontId(theme.id, fontId));
 
+      Uniwind.updateCSSVariables(theme.id, {
+        '--font-heading': font.fontFamily,
+      });
+    }
+
+    return;
+  }
+
+  // Explicit font selection: every theme gets the same font, so resolve once
+  // outside the loop and reuse the same override object for all themes.
+  const font = getTitleFont(normalizeTitleFontSelection(fontId));
   const override: Record<string, string> = {
     '--font-heading': font.fontFamily,
   };
 
-  // Override across all theme variants so the selection persists regardless
-  // of which theme is active.
   for (const theme of THEMES) {
     Uniwind.updateCSSVariables(theme.id, override);
   }

--- a/apps/mobile/src/lib/typography.ts
+++ b/apps/mobile/src/lib/typography.ts
@@ -1,0 +1,199 @@
+import { Platform, type TextStyle } from 'react-native';
+import { Uniwind } from 'uniwind';
+import {
+  DEFAULT_TITLE_FONT,
+  THEMES,
+  TITLE_FONTS,
+  type TitleFontId,
+} from './theme/registry';
+
+export { DEFAULT_TITLE_FONT, TITLE_FONTS, type TitleFontId };
+export const DEFAULT_TITLE_FONT_SELECTION = 'default' as const;
+export type TitleFontSelection = TitleFontId | typeof DEFAULT_TITLE_FONT_SELECTION;
+
+// ── Body Font Size ─────────────────────────────────────────────────
+export const BODY_FONT_SIZES = ['small', 'default', 'large'] as const;
+export type BodyFontSize = (typeof BODY_FONT_SIZES)[number];
+
+/**
+ * Pixel offset applied to every body-text font size.
+ * 'default' (0) leaves sizes unchanged — the phone's system font
+ * scale is applied on top by React Native via `allowFontScaling`.
+ */
+export const FONT_SIZE_DELTA: Record<BodyFontSize, number> = {
+  small: -2,
+  default: 0,
+  large: 2,
+};
+
+// ── Heading Font Metrics ───────────────────────────────────────────
+
+/**
+ * Per-font vertical-metrics adjustments for heading variants (h1–h4).
+ *
+ * ## Why this exists
+ *
+ * ### iOS
+ * Core Text (iOS) sizes a text run's line-box using the font's own internal
+ * ascender + descender metadata, so glyphs are almost never clipped — even
+ * for fonts with extreme metrics. No special treatment is usually needed.
+ *
+ * ### Android
+ * React Native on Android renders text inside a `ReactTextView`
+ * (a subclass of `TextView`). The glyph is drawn into a canvas whose height
+ * equals the computed `lineHeight`. If `lineHeight` is smaller than the
+ * font's full ascender-to-descender span, the glyph is hard-clipped at the
+ * canvas boundary — **regardless of any padding or overflow on the text or
+ * parent views**. `paddingBottom` only adds layout space; it does not expand
+ * the draw canvas. `overflow: visible` on a parent only controls whether
+ * child *views* can paint outside — it has no effect on intra-component
+ * glyph clipping inside `ReactTextView`.
+ *
+ * The **only** fix is a `lineHeight` tall enough to contain the full glyph.
+ *
+ * ## Fields
+ * - `lineHeightScale` — iOS lineHeight = `Math.ceil(fontSize × lineHeightScale)`.
+ * - `bottomTrim` — negative margin (iOS only) to compensate for the extra
+ *   whitespace the enlarged line-box introduces below the last baseline.
+ * - `androidLineHeightScale` — same as `lineHeightScale` but used on Android,
+ *   where deeper descenders often require a larger canvas than iOS needs.
+ *   Falls back to `lineHeightScale` when absent.
+ */
+export interface HeadingFontMetrics {
+  lineHeightScale: number;
+  bottomTrim: number;
+  androidLineHeightScale?: number;
+}
+
+export interface ResolvedHeadingFontMetrics {
+  lineHeight: number;
+  bottomTrim: number;
+}
+
+export const HEADING_FONT_METRICS: Record<string, HeadingFontMetrics> = {
+  // Gloria Hallelujah is a handwriting font with an unusually deep descender
+  // (letters like 'g', 'y', 'p' extend far below the baseline). iOS handles
+  // this via Core Text's font metrics; Android clips the glyph unless
+  // lineHeight is explicitly set large enough to contain the full descent.
+  // Scale 2.0 gives h2 → lineHeight 60px, which clears the deepest descender.
+  GloriaHallelujah_400Regular: {
+    lineHeightScale: 1.4,
+    bottomTrim: -6,
+    androidLineHeightScale: 2.0,
+  },
+};
+
+/** Base font-sizes (px) for each heading variant's Tailwind text-* class. */
+export const HEADING_BASE_SIZE: Record<string, number> = {
+  h1: 36, // text-4xl
+  h2: 30, // text-3xl
+  h3: 24, // text-2xl
+  h4: 20, // text-xl
+};
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/** Look up a title font entry by id. Falls back to the first font if not found. */
+export function getTitleFont(id: string) {
+  return TITLE_FONTS.find((f) => f.id === id) ?? TITLE_FONTS[0]!;
+}
+
+/** Return true when the provided string matches a registered title font ID. */
+export function isKnownTitleFontId(fontId: string): fontId is TitleFontId {
+  return TITLE_FONTS.some((font) => font.id === fontId);
+}
+
+/** Return true when the selection explicitly follows the active theme default. */
+export function isDefaultTitleFontSelection(
+  fontId: string | null | undefined,
+): fontId is typeof DEFAULT_TITLE_FONT_SELECTION {
+  return fontId === DEFAULT_TITLE_FONT_SELECTION;
+}
+
+/** Coerce persisted or user-provided input into a safe title-font selection value. */
+export function normalizeTitleFontSelection(
+  fontId: string | null | undefined,
+): TitleFontSelection {
+  if (!fontId || isDefaultTitleFontSelection(fontId)) {
+    return DEFAULT_TITLE_FONT_SELECTION;
+  }
+
+  return isKnownTitleFontId(fontId) ? fontId : DEFAULT_TITLE_FONT_SELECTION;
+}
+
+/** Return the built-in title font ID for a given theme. */
+export function getThemeDefaultTitleFontId(themeId: string): TitleFontId {
+  return THEMES.find((theme) => theme.id === themeId)?.defaultTitleFontId ?? DEFAULT_TITLE_FONT;
+}
+
+/** Resolve a title-font selection to the concrete font ID that should be rendered. */
+export function resolveTitleFontId(
+  themeId: string,
+  fontId: string | null | undefined,
+): TitleFontId {
+  const normalizedFontId = normalizeTitleFontSelection(fontId);
+
+  return isDefaultTitleFontSelection(normalizedFontId)
+    ? getThemeDefaultTitleFontId(themeId)
+    : normalizedFontId;
+}
+
+/**
+ * Resolve the final `lineHeight` and `bottomTrim` for a heading font at a given size.
+ * Returns `undefined` when no custom metrics are registered for the font family.
+ */
+export function resolveHeadingFontMetrics(
+  fontFamily: string,
+  fontSize: number,
+  platform: string = Platform.OS,
+): ResolvedHeadingFontMetrics | undefined {
+  const metrics = HEADING_FONT_METRICS[fontFamily];
+  if (!metrics) return undefined;
+
+  // Use the Android-specific scale if defined (needed for fonts like Gloria
+  // Hallelujah whose glyph descenders extend beyond a normal lineHeight).
+  // Note: paddingBottom / overflow on parent views do NOT fix glyph
+  // clipping - only lineHeight expands the actual draw canvas on Android.
+  const scale =
+    platform === 'android'
+      ? (metrics.androidLineHeightScale ?? metrics.lineHeightScale)
+      : metrics.lineHeightScale;
+
+  return {
+    lineHeight: Math.ceil(fontSize * scale),
+    bottomTrim: platform === 'android' ? 0 : metrics.bottomTrim,
+  };
+}
+
+/**
+ * Build a `TextStyle` suitable for rendering a font preview at the given size.
+ * Includes heading font metrics (lineHeight) when available.
+ */
+export function getTitleFontPreviewStyle(fontFamily: string, fontSize: number): TextStyle {
+  const resolvedMetrics = resolveHeadingFontMetrics(fontFamily, fontSize);
+
+  return {
+    fontFamily,
+    fontSize,
+    ...(resolvedMetrics ? { lineHeight: resolvedMetrics.lineHeight } : undefined),
+  };
+}
+
+/**
+ * Apply the selected title font by overriding `--font-heading` on every theme.
+ * This should be called when the font setting changes *and* on app boot
+ * (after store hydration).
+ */
+export function applyTitleFont(themeId: string, fontId: string | null | undefined) {
+  const font = getTitleFont(resolveTitleFontId(themeId, fontId));
+
+  const override: Record<string, string> = {
+    '--font-heading': font.fontFamily,
+  };
+
+  // Override across all theme variants so the selection persists regardless
+  // of which theme is active.
+  for (const theme of THEMES) {
+    Uniwind.updateCSSVariables(theme.id, override);
+  }
+}

--- a/apps/mobile/src/screens/home/GratitudeTimeline.tsx
+++ b/apps/mobile/src/screens/home/GratitudeTimeline.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import { format, subDays, startOfDay } from 'date-fns';
 import { LegendList } from '@legendapp/list';
 import {
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from '~/lib/i18n';
 import { useEntriesGroupByDate, useTagMapping } from '~/hooks/useGratitude';
 import { AppLoadingScreen } from '~/components/AppLoadingScreen';
+import { Text } from '~/components/ui/text';
 import { TimelineItem } from './GratitudeTimelineItem';
 import { GratitudeMilestone, isMilestone } from './GratitudeMilestone';
 

--- a/apps/mobile/src/screens/settings/FontPickerSheet.tsx
+++ b/apps/mobile/src/screens/settings/FontPickerSheet.tsx
@@ -15,7 +15,7 @@ import {
   getTitleFontPreviewStyle,
   resolveTitleFontId,
   type TitleFontSelection,
-} from '~/lib/typography';
+} from '~/lib/theme/typography';
 import { Icon } from '~/components/ui/icon';
 import { Text } from '~/components/ui/text';
 import { Button } from '~/components/ui/button';

--- a/apps/mobile/src/screens/settings/FontPickerSheet.tsx
+++ b/apps/mobile/src/screens/settings/FontPickerSheet.tsx
@@ -1,0 +1,153 @@
+import { View, ScrollView } from 'react-native';
+import { TrueSheet } from '@lodev09/react-native-true-sheet';
+import { Check, X } from 'lucide-react-native';
+import { cn } from 'tailwind-variants';
+import { useCSSVariable } from 'uniwind';
+import { SHEET_NAMES } from '~/constants';
+import { useTranslation } from '~/lib/i18n';
+import { useSettingsStore } from '~/lib/settings';
+import { DEFAULT_THEME_SHEET_RADIUS } from '~/lib/theme/themes';
+import {
+  DEFAULT_TITLE_FONT_SELECTION,
+  TITLE_FONTS,
+  getThemeDefaultTitleFontId,
+  getTitleFont,
+  getTitleFontPreviewStyle,
+  resolveTitleFontId,
+  type TitleFontSelection,
+} from '~/lib/typography';
+import { Icon } from '~/components/ui/icon';
+import { Text } from '~/components/ui/text';
+import { Button } from '~/components/ui/button';
+
+function FontCard({
+  label,
+  previewFontFamily,
+  isActive,
+  onSelect,
+}: {
+  label: string;
+  previewFontFamily: string;
+  isActive: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="none"
+      onPress={onSelect}
+      className={cn(
+        'flex-1 min-w-[28%] max-w-[32%] flex-col items-center justify-start rounded-lg p-3',
+        isActive
+          ? 'bg-primary/15 border-2 border-ring'
+          : 'bg-card border-2 border-transparent',
+      )}
+      role="radio"
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: isActive }}>
+      {/* Font preview */}
+      <Text
+        className="text-2xl text-foreground mb-1.5"
+        style={getTitleFontPreviewStyle(previewFontFamily, 24)}>
+        Aa
+      </Text>
+      {/* Label */}
+      <Text
+        className={cn('text-[12px] text-muted-foreground font-body-medium')}
+        numberOfLines={1}>
+        {label}
+      </Text>
+      {/* Selection indicator */}
+      {isActive && (
+        <View className={cn('absolute top-1.5 right-1.5')}>
+          <Icon as={Check} className="text-ring size-4" strokeWidth={3} />
+        </View>
+      )}
+    </Button>
+  );
+}
+
+export function FontPickerSheet() {
+  const { t } = useTranslation();
+  const themeId = useSettingsStore((s) => s.theme);
+  const currentFont = useSettingsStore((s) => s.titleFont);
+  const setTitleFont = useSettingsStore((s) => s.setTitleFont);
+  const themeDefaultFont = getTitleFont(getThemeDefaultTitleFontId(themeId));
+  const activeFontConfig = getTitleFont(resolveTitleFontId(themeId, currentFont));
+  const [backgroundColor, themeRadiusStr, mutedFgColor] = useCSSVariable([
+    '--color-background',
+    '--theme-radius',
+    '--color-muted-foreground',
+  ]);
+  const sheetRadius = String(themeRadiusStr) === '0' ? 0 : DEFAULT_THEME_SHEET_RADIUS;
+
+  return (
+    <TrueSheet
+      name={SHEET_NAMES.FONT_PICKER}
+      detents={['auto']}
+      cornerRadius={sheetRadius}
+      grabber={true}
+      grabberOptions={{
+        topMargin: 8,
+        color: mutedFgColor as string,
+        adaptive: false,
+      }}
+      backgroundColor={backgroundColor as string}>
+      <View className="bg-background pt-2 pb-6">
+        {/* Header */}
+        <View className={cn('items-center justify-between px-5 pt-3 pb-3', 'flex-row')}>
+          <Text className={cn('text-xl font-body-bold text-foreground')}>
+            {t('Title Font')}
+          </Text>
+          <Button
+            onPress={() => TrueSheet.dismiss(SHEET_NAMES.FONT_PICKER)}
+            variant="ghost"
+            className={cn('p-1 -mr-2')}
+            accessibilityLabel={t('Close')}>
+            <Icon as={X} className="text-foreground" />
+          </Button>
+        </View>
+
+        {/* Live preview */}
+        <View className="px-5 py-4 mx-4 mb-4 bg-card rounded-lg border border-border">
+          <Text
+            className={cn('text-xl text-foreground mb-1')}
+            style={getTitleFontPreviewStyle(activeFontConfig.fontFamily, 20)}>
+            {t('Gratitude makes today brighter')}
+          </Text>
+          <Text className={cn('text-sm text-muted-foreground')}>
+            {t('Preview of the selected font')}
+          </Text>
+        </View>
+
+        {/* Font grid */}
+        <ScrollView
+          horizontal={false}
+          contentContainerClassName="px-4 gap-3"
+          showsVerticalScrollIndicator={false}>
+          <View
+            className={cn('flex-row flex-wrap gap-3', 'justify-start')}
+            accessibilityRole="radiogroup"
+            accessibilityLabel={t('Title Font')}>
+            <FontCard
+              label={t('Default')}
+              previewFontFamily={themeDefaultFont.fontFamily}
+              isActive={currentFont === DEFAULT_TITLE_FONT_SELECTION}
+              onSelect={() => setTitleFont(DEFAULT_TITLE_FONT_SELECTION)}
+            />
+            {TITLE_FONTS.map((font) => (
+              <FontCard
+                key={font.id}
+                label={font.label}
+                previewFontFamily={font.fontFamily}
+                isActive={currentFont === font.id}
+                onSelect={() => setTitleFont(font.id as TitleFontSelection)}
+              />
+            ))}
+          </View>
+        </ScrollView>
+      </View>
+    </TrueSheet>
+  );
+}

--- a/apps/mobile/src/screens/settings/ThemePickerSheet.tsx
+++ b/apps/mobile/src/screens/settings/ThemePickerSheet.tsx
@@ -18,7 +18,7 @@ import {
   type ThemeConfig,
   isThemeDark,
 } from '~/lib/theme/themes';
-import { getThemeDefaultTitleFontId, getTitleFont } from '~/lib/typography';
+import { getThemeDefaultTitleFontId, getTitleFont } from '~/lib/theme/typography';
 import { Icon } from '~/components/ui/icon';
 import { Text } from '~/components/ui/text';
 import { Button } from '~/components/ui/button';
@@ -36,9 +36,7 @@ function ThemeCardContent({
 
   // Resolve this theme's original heading font so the preview always shows
   // the curated font, regardless of any user-level title font override.
-  const themeFontFamily = getTitleFont(
-    getThemeDefaultTitleFontId(theme.id),
-  ).fontFamily;
+  const themeFontFamily = getTitleFont(getThemeDefaultTitleFontId(theme.id)).fontFamily;
 
   return (
     <View

--- a/apps/mobile/src/screens/settings/ThemePickerSheet.tsx
+++ b/apps/mobile/src/screens/settings/ThemePickerSheet.tsx
@@ -18,6 +18,7 @@ import {
   type ThemeConfig,
   isThemeDark,
 } from '~/lib/theme/themes';
+import { getThemeDefaultTitleFontId, getTitleFont } from '~/lib/typography';
 import { Icon } from '~/components/ui/icon';
 import { Text } from '~/components/ui/text';
 import { Button } from '~/components/ui/button';
@@ -33,6 +34,12 @@ function ThemeCardContent({
 }) {
   const [colorForeground] = useCSSVariable(['--color-foreground']);
 
+  // Resolve this theme's original heading font so the preview always shows
+  // the curated font, regardless of any user-level title font override.
+  const themeFontFamily = getTitleFont(
+    getThemeDefaultTitleFontId(theme.id),
+  ).fontFamily;
+
   return (
     <View
       className={cn(
@@ -44,7 +51,9 @@ function ThemeCardContent({
         {/* Left spacer for perfect centering */}
         <View className="w-4" />
 
-        <Text className="text-sm font-heading font-bold text-primary-foreground">
+        <Text
+          className="text-sm font-bold text-primary-foreground"
+          style={{ fontFamily: themeFontFamily }}>
           Tackbok
         </Text>
 
@@ -67,7 +76,9 @@ function ThemeCardContent({
 
         {/* Content Column */}
         <View className="flex-1 pl-4 pr-3 py-3 gap-1.5">
-          <Text className="text-base font-heading font-bold text-foreground">
+          <Text
+            className="text-base font-bold text-foreground"
+            style={{ fontFamily: themeFontFamily }}>
             {theme.name}
           </Text>
 

--- a/apps/mobile/src/screens/settings/ThemePickerSheet.tsx
+++ b/apps/mobile/src/screens/settings/ThemePickerSheet.tsx
@@ -50,7 +50,7 @@ function ThemeCardContent({
         <View className="w-4" />
 
         <Text
-          className="text-sm font-bold text-primary-foreground"
+          className="text-sm text-primary-foreground"
           style={{ fontFamily: themeFontFamily }}>
           Tackbok
         </Text>
@@ -75,7 +75,7 @@ function ThemeCardContent({
         {/* Content Column */}
         <View className="flex-1 pl-4 pr-3 py-3 gap-1.5">
           <Text
-            className="text-base font-bold text-foreground"
+            className="text-base text-foreground"
             style={{ fontFamily: themeFontFamily }}>
             {theme.name}
           </Text>

--- a/apps/mobile/src/screens/settings/index.tsx
+++ b/apps/mobile/src/screens/settings/index.tsx
@@ -7,12 +7,14 @@ import { Icon } from '~/components/ui/icon';
 import { Button } from '~/components/ui/button';
 import { NotificationsSection } from './sections/NotificationsSection';
 import { AppearanceSection } from './sections/AppearanceSection';
+import { TypographySection } from './sections/TypographySection';
 import { JournalingSection } from './sections/JournalingSection';
 import { SecuritySection } from './sections/SecuritySection';
 import { BackupRestoreSection } from './sections/BackupRestoreSection';
 import { AppInfoSection } from './sections/AppInfoSection';
 import { DangerZoneSection } from './sections/DangerZoneSection';
 import { ThemePickerSheet } from './ThemePickerSheet';
+import { FontPickerSheet } from './FontPickerSheet';
 import { JournalFocusAreasSheet } from './JournalFocusAreasSheet';
 
 export default function SettingsScreen() {
@@ -39,6 +41,7 @@ export default function SettingsScreen() {
         {/* Settings Content */}
         <ScrollView className="px-safe">
           <NotificationsSection />
+          <TypographySection />
           <AppearanceSection />
           <JournalingSection />
           <SecuritySection />
@@ -52,6 +55,7 @@ export default function SettingsScreen() {
       </View>
 
       <ThemePickerSheet />
+      <FontPickerSheet />
       <JournalFocusAreasSheet />
     </>
   );

--- a/apps/mobile/src/screens/settings/sections/TypographySection.tsx
+++ b/apps/mobile/src/screens/settings/sections/TypographySection.tsx
@@ -11,7 +11,7 @@ import {
   getTitleFont,
   resolveTitleFontId,
   type BodyFontSize,
-} from '~/lib/typography';
+} from '~/lib/theme/typography';
 import { Text } from '~/components/ui/text';
 import { Icon } from '~/components/ui/icon';
 import { Button } from '~/components/ui/button';
@@ -37,7 +37,10 @@ const TILE_PREVIEW_SIZE: Record<BodyFontSize, number> = {
 
 export function TypographySection() {
   const { t } = useTranslation();
-  const { theme, titleFont, bodyFontSize, setBodyFontSize } = useSettingsStore();
+  const theme = useSettingsStore((s) => s.theme);
+  const titleFont = useSettingsStore((s) => s.titleFont);
+  const bodyFontSize = useSettingsStore((s) => s.bodyFontSize);
+  const setBodyFontSize = useSettingsStore((s) => s.setBodyFontSize);
 
   const activeTitleFont = getTitleFont(resolveTitleFontId(theme, titleFont));
 

--- a/apps/mobile/src/screens/settings/sections/TypographySection.tsx
+++ b/apps/mobile/src/screens/settings/sections/TypographySection.tsx
@@ -1,0 +1,117 @@
+import { View } from 'react-native';
+import { Type, ALargeSmall } from 'lucide-react-native';
+import { TrueSheet } from '@lodev09/react-native-true-sheet';
+import { cn } from 'tailwind-variants';
+import { SHEET_NAMES } from '~/constants';
+import { useTranslation } from '~/lib/i18n';
+import { useSettingsStore } from '~/lib/settings';
+import {
+  BODY_FONT_SIZES,
+  DEFAULT_TITLE_FONT_SELECTION,
+  getTitleFont,
+  resolveTitleFontId,
+  type BodyFontSize,
+} from '~/lib/typography';
+import { Text } from '~/components/ui/text';
+import { Icon } from '~/components/ui/icon';
+import { Button } from '~/components/ui/button';
+import { SettingsSection } from '../SettingsSection';
+import { SettingsRow } from '../SettingsRow';
+
+/** Labels shown under each font-size tile. */
+const SIZE_LABELS: Record<BodyFontSize, string> = {
+  small: 'Small',
+  default: 'Default',
+  large: 'Large',
+};
+
+/**
+ * The "Aa" preview size rendered in each tile — deliberately different from
+ * the actual font-size setting so the difference between tiles is visible.
+ */
+const TILE_PREVIEW_SIZE: Record<BodyFontSize, number> = {
+  small: 16,
+  default: 20,
+  large: 24,
+};
+
+export function TypographySection() {
+  const { t } = useTranslation();
+  const { theme, titleFont, bodyFontSize, setBodyFontSize } = useSettingsStore();
+
+  const activeTitleFont = getTitleFont(resolveTitleFontId(theme, titleFont));
+
+  return (
+    <SettingsSection title={t('Typography')}>
+      {/* Title font row */}
+      <SettingsRow
+        label={t('Title Font')}
+        description={t('Choose a font for titles and headings')}
+        icon={Type}
+        onPress={() => TrueSheet.present(SHEET_NAMES.FONT_PICKER)}
+        showChevron
+        rightElement={
+          <Text className="text-base text-muted-foreground">
+            {titleFont === DEFAULT_TITLE_FONT_SELECTION
+              ? t('Default')
+              : activeTitleFont.label}
+          </Text>
+        }
+      />
+
+      {/* Body font size — tile picker */}
+      <View className="px-3 py-3 border-b-0">
+        <View className={cn('items-start flex-row')}>
+          <View className={cn('mt-0.5 mr-3')}>
+            <Icon as={ALargeSmall} strokeWidth={2} className="text-foreground size-5" />
+          </View>
+          <View className={cn('flex-1')}>
+            <Text className={cn('text-base font-body-medium text-foreground')}>
+              {t('Font Size')}
+            </Text>
+            <Text className={cn('text-sm text-foreground/80 mt-0.5 mb-3')}>
+              {t('Adjust the size of body text')}
+            </Text>
+
+            {/* Size tiles */}
+            <View
+              className={cn('flex-row gap-3 justify-start')}
+              accessibilityRole="radiogroup"
+              accessibilityLabel={t('Font Size')}>
+              {BODY_FONT_SIZES.map((size) => {
+                const isActive = bodyFontSize === size;
+                return (
+                  <Button
+                    key={size}
+                    variant="ghost"
+                    size="none"
+                    onPress={() => setBodyFontSize(size)}
+                    role="radio"
+                    accessibilityRole="radio"
+                    accessibilityLabel={t(SIZE_LABELS[size])}
+                    accessibilityState={{ selected: isActive }}
+                    className={cn(
+                      'flex-1 flex-col items-center justify-center rounded-lg py-3',
+                      isActive
+                        ? 'bg-primary/15 border-2 border-ring'
+                        : 'bg-card border-2 border-transparent',
+                    )}>
+                    <Text
+                      className={cn('text-foreground mb-1 font-body-semibold')}
+                      style={{ fontSize: TILE_PREVIEW_SIZE[size] }}>
+                      Aa
+                    </Text>
+                    <Text
+                      className={cn('text-xs text-muted-foreground font-body-medium')}>
+                      {t(SIZE_LABELS[size])}
+                    </Text>
+                  </Button>
+                );
+              })}
+            </View>
+          </View>
+        </View>
+      </View>
+    </SettingsSection>
+  );
+}


### PR DESCRIPTION
- Added `FontPickerSheet` and `TypographySection` to settings page
- Expanded `settings/store` to persist user font preferences
- Replaced standard React Native `Text` components with custom `AppText` across UI primitives (`dialog`, `label`, `toast`, `GratitudeTimeline`)
- Added translation strings for typography features across all supported languages

@coderabbitai full review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added typography settings section with font selection and size adjustment options
  * Added font picker interface for title font customization
  * Added body text size controls with default, small, and large variants
  * Multi-language support for typography settings (Arabic, Chinese Simplified, Chinese Traditional, English, Hebrew)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->