### PR TITLE
refactor(test): migrate from bun test to jest framework

### DIFF
--- a/apps/mobile/__mocks__/expo-file-system.ts
+++ b/apps/mobile/__mocks__/expo-file-system.ts
@@ -1,0 +1,70 @@
+export const __mockFileSystemState = {
+  pickDirectoryAsync: jest.fn(async () => ({
+    createFile: jest.fn((name: string) => ({
+      uri: `picked/${name}`,
+      write: jest.fn(() => {}),
+    })),
+  })),
+  cacheEntries: [] as unknown[],
+  paths: {
+    cache: '/tmp',
+    document: '/documents',
+  },
+};
+
+export class File {
+  exists = true;
+  modificationTime: number | null = Date.now();
+  creationTime: number | null = Date.now();
+  bytes = jest.fn(async () => new Uint8Array([1, 2, 3]));
+  copy = jest.fn((_destination: unknown) => {});
+  uri: string;
+
+  constructor(...args: unknown[]) {
+    this.uri = args
+      .map((arg) => {
+        if (typeof arg === 'string') {
+          return arg;
+        }
+
+        if (arg && typeof arg === 'object' && 'uri' in arg) {
+          return String((arg as { uri?: unknown }).uri ?? '');
+        }
+
+        return '';
+      })
+      .filter(Boolean)
+      .join('/');
+  }
+
+  delete() {
+    this.exists = false;
+  }
+
+  write(_content: Uint8Array) {}
+}
+
+export class Directory {
+  static pickDirectoryAsync() {
+    return __mockFileSystemState.pickDirectoryAsync();
+  }
+
+  exists = true;
+
+  constructor(...args: unknown[]) {
+    void args;
+  }
+
+  createFile(name: string, _mimeType: string | null) {
+    return {
+      uri: `picked/${name}`,
+      write: jest.fn(() => {}),
+    };
+  }
+
+  list() {
+    return __mockFileSystemState.cacheEntries as File[];
+  }
+}
+
+export const Paths = __mockFileSystemState.paths;

--- a/apps/mobile/__mocks__/react-native.ts
+++ b/apps/mobile/__mocks__/react-native.ts
@@ -1,0 +1,10 @@
+export const Platform = {
+  OS: 'ios',
+  select<T>(options: { ios?: T; android?: T; default?: T }) {
+    return options[this.OS as 'ios' | 'android'] ?? options.default;
+  },
+};
+
+export const __mockReactNativeState = {
+  Platform,
+};

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -10,10 +10,9 @@
     "generate:themes": "bun run src/lib/theme/generate-theme-artifacts.ts",
     "generate:themes:verify": "bun run generate:themes && bun run test:theme",
     "lint": "expo lint",
-    "test": "bun run test:jest && bun run test:bun",
+    "test": "bun run test:jest",
     "test:jest": "jest",
-    "test:theme": "jest src/lib/theme/theme-registry.test.ts src/lib/theme/metro-config.test.ts",
-    "test:bun": "bun test src/lib/zip src/lib/backupExport src/lib/backupImport"
+    "test:theme": "jest src/lib/theme/theme-registry.test.ts src/lib/theme/metro-config.test.ts"
   },
   "dependencies": {
     "@expo-google-fonts/cinzel": "^0.4.2",
@@ -82,11 +81,6 @@
   "private": true,
   "jest": {
     "preset": "jest-expo",
-    "testPathIgnorePatterns": [
-      "<rootDir>/src/lib/zip/",
-      "<rootDir>/src/lib/backupExport/",
-      "<rootDir>/src/lib/backupImport/"
-    ],
     "transformIgnorePatterns": [
       "node_modules/(?!.*((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg))"
     ]

--- a/apps/mobile/src/lib/backupExport/tackbok.test.ts
+++ b/apps/mobile/src/lib/backupExport/tackbok.test.ts
@@ -1,22 +1,13 @@
 import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  spyOn,
-  test,
-} from 'bun:test';
-import {
   BACKUP_ENTRIES_PATH,
   BACKUP_MANIFEST_PATH,
   BACKUP_PROFILE_PATH,
 } from '../backupImport/types';
+import { exportToBackupZip } from './tackbok';
+
+const spyOn = jest.spyOn;
 
 (globalThis as { __DEV__?: boolean }).__DEV__ = false;
-
-let exportToBackupZip: () => Promise<void>;
 
 type PortableEntryMock = {
   noteId: string;
@@ -34,27 +25,29 @@ type PortableEntryMock = {
   }[];
 };
 
-const mockAddFile = mock(async (_path: string, _file: unknown): Promise<void> => {});
-const mockAddText = mock(async (_path: string, _text: string): Promise<void> => {});
-const mockClose = mock(async (): Promise<void> => {});
-const mockAbort = mock(async (): Promise<void> => {});
-const mockSaveGeneratedZipFile = mock(
+const mockAddFile = jest.fn(async (_path: string, _file: unknown): Promise<void> => {});
+const mockAddText = jest.fn(async (_path: string, _text: string): Promise<void> => {});
+const mockClose = jest.fn(async (): Promise<void> => {});
+const mockAbort = jest.fn(async (): Promise<void> => {});
+const mockSaveGeneratedZipFile = jest.fn(
   async (
     _file: unknown,
     _name: string,
   ): Promise<'delete-immediately' | 'defer-cleanup'> => 'delete-immediately',
 );
-const mockCleanupDeferredBackupZipFiles = mock((_minAgeMs?: number, _now?: number) => {});
-const mockGetRelativeAssetFile = mock((relativeUri: string) => ({
+const mockCleanupDeferredBackupZipFiles = jest.fn(
+  (_minAgeMs?: number, _now?: number) => {},
+);
+const mockGetRelativeAssetFile = jest.fn((relativeUri: string) => ({
   exists: true,
   uri: relativeUri,
 }));
-const mockGetState = mock(() => ({
+const mockGetState = jest.fn(() => ({
   profileName: 'Ada',
   profileEmail: 'ada@example.com',
   profileImageUri: 'photos/profile.jpg',
 }));
-const mockCreatePortableEntries = mock(
+const mockCreatePortableEntries = jest.fn(
   (
     _allEntries: unknown,
     _tagMap: unknown,
@@ -64,10 +57,10 @@ const mockCreatePortableEntries = mock(
     portableEntries: [],
   }),
 );
-const mockCreatePortableTags = mock((_allTags: unknown): unknown[] => []);
-const mockCreatePortablePrompts = mock((_allPrompts: unknown): unknown[] => []);
+const mockCreatePortableTags = jest.fn((_allTags: unknown): unknown[] => []);
+const mockCreatePortablePrompts = jest.fn((_allPrompts: unknown): unknown[] => []);
 
-mock.module('expo-file-system', () => ({
+jest.mock('expo-file-system', () => ({
   File: class MockFile {
     exists = true;
 
@@ -86,16 +79,16 @@ mock.module('expo-file-system', () => ({
   },
 }));
 
-const dbMockFactory = () => {
-  const entries = { created_at: 'created_at' };
+jest.mock('~/db', () => {
+  const mockEntries = { created_at: 'created_at' };
 
   return {
     db: {
-      select: mock(() => ({
-        from: mock((table: unknown) => {
-          if (table === entries) {
+      select: jest.fn(() => ({
+        from: jest.fn((table: unknown) => {
+          if (table === mockEntries) {
             return {
-              orderBy: mock(async () => []),
+              orderBy: jest.fn(async () => []),
             };
           }
 
@@ -104,29 +97,23 @@ const dbMockFactory = () => {
       })),
     },
     customPrompts: {},
-    entries,
+    entries: mockEntries,
     tags: {},
   };
-};
+});
 
-mock.module('~/db', dbMockFactory);
-mock.module('~/db/index.ts', dbMockFactory);
-
-const settingsMockFactory = () => ({
+jest.mock('~/lib/settings', () => ({
   useSettingsStore: {
     getState: () => mockGetState(),
   },
-});
+}));
 
-mock.module('~/lib/settings', settingsMockFactory);
-mock.module('~/lib/settings/index.ts', settingsMockFactory);
-
-mock.module('~/lib/zip', () => ({
+jest.mock('~/lib/zip', () => ({
   createExpoZipWriter: (outputFile: unknown) => ({
     outputFile,
-    addBytes: mock(() => {}),
+    addBytes: jest.fn(() => {}),
     addText: mockAddText,
-    addStored: mock(() => {}),
+    addStored: jest.fn(() => {}),
     addFile: mockAddFile,
     close: mockClose,
     abort: mockAbort,
@@ -143,12 +130,10 @@ mock.module('~/lib/zip', () => ({
 
     return match?.path ?? null;
   },
-  createZipEntryLookup: (
-    zip: {
-      hasEntry: (path: string) => boolean;
-      listEntries: () => { path: string }[];
-    },
-  ) => ({
+  createZipEntryLookup: (zip: {
+    hasEntry: (path: string) => boolean;
+    listEntries: () => { path: string }[];
+  }) => ({
     hasPath: (path: string) => zip.hasEntry(path),
     findByBasename: (basename: string) => {
       const safeBasename = basename.trim();
@@ -189,9 +174,9 @@ mock.module('~/lib/zip', () => ({
   }),
 }));
 
-mock.module('../backupImport/archiveUtils', () => ({
+jest.mock('../backupImport/archiveUtils', () => ({
   VALID_MOODS: new Set(['Joyful', 'Calm', 'Neutral', 'Anxious', 'Sad', 'Angry']),
-  normalizeOptionalText: mock((value: string | null | undefined) => {
+  normalizeOptionalText: jest.fn((value: string | null | undefined) => {
     const trimmed = value?.trim();
     return trimmed ? trimmed : null;
   }),
@@ -251,20 +236,21 @@ mock.module('../backupImport/archiveUtils', () => ({
   },
 }));
 
-mock.module('./utils', () => ({
-  generateTimestamp: mock(() => '2026-04-22T10-00-00'),
+jest.mock('./utils', () => ({
+  generateTimestamp: jest.fn(() => '2026-04-22T10-00-00'),
   saveOrShareZipFile: (file: unknown, fileName: string) =>
     mockSaveGeneratedZipFile(file, fileName),
   cleanupDeferredBackupZipFiles: (minAgeMs?: number, now?: number) =>
     mockCleanupDeferredBackupZipFiles(minAgeMs, now),
-  buildTagIdToNameMap: mock(async () => new Map()),
+  buildTagIdToNameMap: jest.fn(async () => new Map()),
   resolveTagIdsToTitles: (_tagIds: string, _tagMap: Map<string, string>) => [],
   getRelativeAssetFile: (relativeUri: string) => mockGetRelativeAssetFile(relativeUri),
-  createArchiveAssetPath: (_type: string, relativeUri: string) => `media/photos/${relativeUri}`,
+  createArchiveAssetPath: (_type: string, relativeUri: string) =>
+    `media/photos/${relativeUri}`,
   assetFileExists: (_asset: unknown) => true,
 }));
 
-mock.module('./portable', () => ({
+jest.mock('./portable', () => ({
   createPortableEntries: (allEntries: unknown, tagMap: unknown) =>
     mockCreatePortableEntries(allEntries, tagMap),
   createPortablePrompts: (allPrompts: unknown) => mockCreatePortablePrompts(allPrompts),
@@ -272,10 +258,6 @@ mock.module('./portable', () => ({
 }));
 
 describe('exportToBackupZip', () => {
-  beforeAll(async () => {
-    ({ exportToBackupZip } = await import('./tackbok'));
-  });
-
   beforeEach(() => {
     mockAddFile.mockReset();
     mockAddText.mockReset();
@@ -352,13 +334,16 @@ describe('exportToBackupZip', () => {
     expect(warnSpy).toHaveBeenCalledTimes(2);
 
     const entriesJson = JSON.parse(
-      mockAddText.mock.calls.find(([path]) => path === BACKUP_ENTRIES_PATH)?.[1] ?? 'null',
+      mockAddText.mock.calls.find(([path]) => path === BACKUP_ENTRIES_PATH)?.[1] ??
+        'null',
     );
     const profileJson = JSON.parse(
-      mockAddText.mock.calls.find(([path]) => path === BACKUP_PROFILE_PATH)?.[1] ?? 'null',
+      mockAddText.mock.calls.find(([path]) => path === BACKUP_PROFILE_PATH)?.[1] ??
+        'null',
     );
     const manifestJson = JSON.parse(
-      mockAddText.mock.calls.find(([path]) => path === BACKUP_MANIFEST_PATH)?.[1] ?? 'null',
+      mockAddText.mock.calls.find(([path]) => path === BACKUP_MANIFEST_PATH)?.[1] ??
+        'null',
     );
 
     expect(entriesJson).toEqual([
@@ -401,9 +386,5 @@ describe('exportToBackupZip', () => {
 
     const sharedFile = mockSaveGeneratedZipFile.mock.calls[0]?.[0] as { exists: boolean };
     expect(sharedFile.exists).toBe(true);
-  });
-
-  afterAll(() => {
-    mock.restore();
   });
 });

--- a/apps/mobile/src/lib/backupExport/utils.test.ts
+++ b/apps/mobile/src/lib/backupExport/utils.test.ts
@@ -1,77 +1,45 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as ExpoFileSystemMock from 'expo-file-system';
+import { File, type File as ExpoFile } from 'expo-file-system';
+import * as ReactNativeMock from 'react-native';
+import {
+  cleanupDeferredBackupZipFiles,
+  getRelativeAssetFile,
+  saveOrShareZipFile,
+} from './utils';
+
+type MockExpoFile = InstanceType<typeof File> & ExpoFile;
+
+const { __mockFileSystemState } = ExpoFileSystemMock as typeof ExpoFileSystemMock & {
+  __mockFileSystemState: {
+    pickDirectoryAsync: jest.Mock;
+    cacheEntries: unknown[];
+  };
+};
+const { __mockReactNativeState } = ReactNativeMock as typeof ReactNativeMock & {
+  __mockReactNativeState: {
+    Platform: {
+      OS: string;
+    };
+  };
+};
 
 (globalThis as { __DEV__?: boolean }).__DEV__ = false;
 
-const mockPickDirectoryAsync = mock(async () => ({
-  createFile: mock(() => ({
-    write: mock(() => {}),
-  })),
-}));
-const mockShareAsync = mock(async (_uri?: string, _options?: unknown) => {});
-const mockIsAvailableAsync = mock(async () => true);
-const mockCacheEntries: unknown[] = [];
-const mockPlatform = {
-  OS: 'ios',
-};
+const mockShareAsync = jest.fn(async (_uri?: string, _options?: unknown) => {});
+const mockIsAvailableAsync = jest.fn(async () => true);
+jest.mock('expo-file-system');
 
-mock.module('expo-file-system', () => ({
-  File: class MockFile {
-    exists = true;
-    modificationTime: number | null = Date.now();
-    creationTime: number | null = Date.now();
-    bytes = mock(async () => new Uint8Array([1, 2, 3]));
-    copy = mock((_destination: unknown) => {});
-
-    constructor(...args: string[]) {
-      this.uri = args.join('/');
-    }
-
-    uri: string;
-
-    delete() {
-      this.exists = false;
-    }
-
-    write(_content: Uint8Array) {}
-  },
-  Directory: class MockDirectory {
-    static pickDirectoryAsync = () => mockPickDirectoryAsync();
-    exists = true;
-
-    constructor(...args: unknown[]) {
-      void args;
-    }
-
-    createFile(name: string, _mimeType: string | null) {
-      return {
-        uri: `picked/${name}`,
-        write: mock(() => {}),
-      };
-    }
-
-    list() {
-      return mockCacheEntries as unknown[];
-    }
-  },
-  Paths: {
-    cache: '/tmp',
-    document: '/documents',
-  },
-}));
-
-mock.module('expo-sharing', () => ({
+jest.mock('expo-sharing', () => ({
   shareAsync: (uri: string, options?: unknown) => mockShareAsync(uri, options),
   isAvailableAsync: () => mockIsAvailableAsync(),
 }));
 
-mock.module('react-native', () => ({
-  Platform: mockPlatform,
-}));
+jest.mock('react-native');
 
-mock.module('~/db', () => ({
+jest.mock('~/db', () => ({
   db: {
-    select: mock(() => ({
-      from: mock(async () => []),
+    select: jest.fn(() => ({
+      from: jest.fn(async () => []),
     })),
   },
   customPrompts: {},
@@ -79,29 +47,25 @@ mock.module('~/db', () => ({
   tags: {},
 }));
 
-mock.module('~/lib/photoUtils', () => ({
+jest.mock('~/lib/photoUtils', () => ({
   photoFileExists: (_uri: string) => true,
 }));
 
-mock.module('~/lib/voiceMemoUtils', () => ({
+jest.mock('~/lib/voiceMemoUtils', () => ({
   voiceMemoFileExists: (_uri: string) => true,
 }));
 
-const { cleanupDeferredBackupZipFiles, getRelativeAssetFile, saveOrShareZipFile } =
-  await import('./utils');
-const { File } = await import('expo-file-system');
-
 describe('backup export utils', () => {
   beforeEach(() => {
-    mockPickDirectoryAsync.mockReset();
+    __mockFileSystemState.pickDirectoryAsync.mockReset();
     mockShareAsync.mockReset();
     mockIsAvailableAsync.mockReset();
-    mockCacheEntries.length = 0;
-    mockPlatform.OS = 'ios';
+    __mockFileSystemState.cacheEntries.length = 0;
+    __mockReactNativeState.Platform.OS = 'ios';
 
-    mockPickDirectoryAsync.mockResolvedValue({
-      createFile: mock(() => ({
-        write: mock(() => {}),
+    __mockFileSystemState.pickDirectoryAsync.mockResolvedValue({
+      createFile: jest.fn(() => ({
+        write: jest.fn(() => {}),
       })),
     });
     mockShareAsync.mockResolvedValue();
@@ -109,7 +73,7 @@ describe('backup export utils', () => {
   });
 
   test('returns deferred cleanup when using the iOS share sheet', async () => {
-    const file = new File('/tmp/TackbokBackup_test.zip');
+    const file = new File('/tmp/TackbokBackup_test.zip') as MockExpoFile;
 
     await expect(saveOrShareZipFile(file, 'TackbokBackup_test.zip')).resolves.toBe(
       'defer-cleanup',
@@ -118,13 +82,13 @@ describe('backup export utils', () => {
   });
 
   test('returns immediate cleanup after android directory copy', async () => {
-    mockPlatform.OS = 'android';
-    const file = new File('/tmp/TackbokBackup_test.zip');
+    __mockReactNativeState.Platform.OS = 'android';
+    const file = new File('/tmp/TackbokBackup_test.zip') as MockExpoFile;
 
     await expect(saveOrShareZipFile(file, 'TackbokBackup_test.zip')).resolves.toBe(
       'delete-immediately',
     );
-    expect(mockPickDirectoryAsync).toHaveBeenCalledTimes(1);
+    expect(__mockFileSystemState.pickDirectoryAsync).toHaveBeenCalledTimes(1);
     expect(file.copy).toHaveBeenCalledTimes(1);
     expect(file.bytes).not.toHaveBeenCalled();
   });
@@ -139,7 +103,7 @@ describe('backup export utils', () => {
     const unrelatedFile = new File('/tmp/not-a-backup.zip');
     unrelatedFile.modificationTime = 1_000;
 
-    mockCacheEntries.push(staleBackup, freshBackup, unrelatedFile);
+    __mockFileSystemState.cacheEntries.push(staleBackup, freshBackup, unrelatedFile);
 
     cleanupDeferredBackupZipFiles(5_000, 10_000);
 
@@ -152,7 +116,7 @@ describe('backup export utils', () => {
     const unknownAgeBackup = new File('/tmp/TackbokBackup_unknown.zip');
     unknownAgeBackup.modificationTime = null;
     unknownAgeBackup.creationTime = null;
-    mockCacheEntries.push(unknownAgeBackup);
+    __mockFileSystemState.cacheEntries.push(unknownAgeBackup);
 
     cleanupDeferredBackupZipFiles(5_000, 10_000);
 

--- a/apps/mobile/src/lib/backupImport/import/presently.test.ts
+++ b/apps/mobile/src/lib/backupImport/import/presently.test.ts
@@ -1,15 +1,13 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { importFromPresentlyCSV } from './presently';
 
-let importFromPresentlyCSV: typeof import('./presently').importFromPresentlyCSV;
-
-const mockFileText = mock(async () => '');
-const mockSelect = mock(() => ({ from: mockFrom }));
-const mockFrom = mock(() => ({ where: mockWhere }));
-const mockWhere = mock(() => ({ limit: mockLimit }));
-const mockLimit = mock(async () => []);
-const mockValues = mock(async () => undefined);
-const mockInsert = mock(() => ({ values: mockValues }));
-const mockTransaction = mock(
+const mockFileText = jest.fn(async () => '');
+const mockLimit = jest.fn(async () => []);
+const mockWhere = jest.fn(() => ({ limit: mockLimit }));
+const mockFrom = jest.fn(() => ({ where: mockWhere }));
+const mockSelect = jest.fn(() => ({ from: mockFrom }));
+const mockValues = jest.fn(async () => undefined);
+const mockInsert = jest.fn(() => ({ values: mockValues }));
+const mockTransaction = jest.fn(
   async (
     callback: (tx: {
       select: typeof mockSelect;
@@ -21,14 +19,14 @@ const mockTransaction = mock(
       insert: mockInsert,
     }),
 );
-const mockGenerateUUID = mock(() => 'generated-note-id');
-const mockReportImportProgress = mock(() => {});
+const mockGenerateUUID = jest.fn(() => 'generated-note-id');
+const mockReportImportProgress = jest.fn(() => {});
 
-mock.module('expo-document-picker', () => ({
-  getDocumentAsync: mock(async () => ({ canceled: true })),
+jest.mock('expo-document-picker', () => ({
+  getDocumentAsync: jest.fn(async () => ({ canceled: true })),
 }));
 
-mock.module('expo-file-system', () => ({
+jest.mock('expo-file-system', () => ({
   File: class MockFile {
     text() {
       return mockFileText();
@@ -36,12 +34,12 @@ mock.module('expo-file-system', () => ({
   },
 }));
 
-mock.module('drizzle-orm', () => ({
+jest.mock('drizzle-orm', () => ({
   and: (...conditions: unknown[]) => ({ type: 'and', conditions }),
   eq: (left: unknown, right: unknown) => ({ type: 'eq', left, right }),
 }));
 
-mock.module('~/db', () => ({
+jest.mock('~/db', () => ({
   db: {
     transaction: (callback: Parameters<typeof mockTransaction>[0]) =>
       mockTransaction(callback),
@@ -53,20 +51,16 @@ mock.module('~/db', () => ({
   },
 }));
 
-mock.module('~/lib/utils', () => ({
+jest.mock('~/lib/utils', () => ({
   generateUUID: () => mockGenerateUUID(),
 }));
 
-mock.module('../progress', () => ({
+jest.mock('../progress', () => ({
   reportImportProgress: (...args: Parameters<typeof mockReportImportProgress>) =>
     mockReportImportProgress(...args),
 }));
 
 describe('importFromPresentlyCSV', () => {
-  beforeAll(async () => {
-    ({ importFromPresentlyCSV } = await import('./presently'));
-  });
-
   beforeEach(() => {
     mockFileText.mockReset();
     mockSelect.mockClear();

--- a/apps/mobile/src/lib/backupImport/import/tackbok.test.ts
+++ b/apps/mobile/src/lib/backupImport/import/tackbok.test.ts
@@ -1,53 +1,48 @@
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  spyOn,
-  test,
-} from 'bun:test';
+import { importFromTackbokBackup } from './tackbok';
 
-let importFromTackbokBackup: (
-  uri: string,
-  mode: 'skip' | 'overwrite',
-) => Promise<{
-  failedProfileAssets: number;
-  warnings: Record<string, unknown>[];
-}>;
+const spyOn = jest.spyOn;
 
-const txSelectFrom = mock(async (_table: unknown): Promise<{ note_id: string }[]> => []);
-const txSelect = mock(() => ({ from: txSelectFrom }));
+const txSelectFrom = jest.fn(
+  async (_table: unknown): Promise<{ note_id: string }[]> => [],
+);
+const txSelect = jest.fn(() => ({ from: txSelectFrom }));
 const tx = { select: txSelect };
-const mockTransaction = mock(
+const mockTransaction = jest.fn(
   async (callback: (transaction: typeof tx) => Promise<void>) => callback(tx),
 );
-const mockIsZipFile = mock((_uri: string): boolean => true);
-const mockLoadZipFromUri = mock(
+const mockIsZipFile = jest.fn((_uri: string): boolean => true);
+const mockLoadZipFromUri = jest.fn(
   async (_uri: string): Promise<{ close: () => Promise<void> }> => ({
-    close: mock(async () => undefined),
+    close: jest.fn(async () => undefined),
   }),
 );
-const mockReadSafeZipJson = mock(
+const mockReadSafeZipJson = jest.fn(
   async (_zip: unknown, _path: string): Promise<unknown> => undefined,
 );
-const mockReadSafeZipBytes = mock(async (_zip: unknown, _path: string) => new Uint8Array());
-const mockWriteImportedPhoto = mock(
+const mockReadSafeZipBytes = jest.fn(
+  async (_zip: unknown, _path: string) => new Uint8Array(),
+);
+const mockWriteImportedPhoto = jest.fn(
   async (_bytes: Uint8Array, _path: string): Promise<{ uri: string }> => ({
     uri: 'photos/imported.jpg',
   }),
 );
-const mockCleanupImportedFiles = mock((_relativeUris: string[]): void => {});
-const mockUpsertPortableTags = mock(
-  async (_tx: unknown, _portableTags: unknown, _summary: unknown): Promise<Map<string, string>> =>
-    new Map(),
+const mockCleanupImportedFiles = jest.fn((_relativeUris: string[]): void => {});
+const mockUpsertPortableTags = jest.fn(
+  async (
+    _tx: unknown,
+    _portableTags: unknown,
+    _summary: unknown,
+  ): Promise<Map<string, string>> => new Map(),
 );
-const mockEnsurePortablePromptTitles = mock(
-  async (_tx: unknown, _portablePrompts: unknown, _summary: unknown): Promise<Set<string>> =>
-    new Set(),
+const mockEnsurePortablePromptTitles = jest.fn(
+  async (
+    _tx: unknown,
+    _portablePrompts: unknown,
+    _summary: unknown,
+  ): Promise<Set<string>> => new Set(),
 );
-const mockImportPortableEntries = mock(
+const mockImportPortableEntries = jest.fn(
   async (
     _tx: unknown,
     _portableEntries: unknown,
@@ -60,10 +55,16 @@ const mockImportPortableEntries = mock(
     _source: unknown,
   ): Promise<void> => undefined,
 );
-const mockApplyImportedProfile = mock((_profile: unknown, _imageUri: string | null) => {});
-const mockGetImportTotals = mock(() => ({ totalEntries: 0, totalTags: 0, totalPrompts: 0 }));
+const mockApplyImportedProfile = jest.fn(
+  (_profile: unknown, _imageUri: string | null) => {},
+);
+const mockGetImportTotals = jest.fn(() => ({
+  totalEntries: 0,
+  totalTags: 0,
+  totalPrompts: 0,
+}));
 
-mock.module('~/db', () => ({
+jest.mock('~/db', () => ({
   db: {
     transaction: (callback: (transaction: typeof tx) => Promise<void>) =>
       mockTransaction(callback),
@@ -71,7 +72,7 @@ mock.module('~/db', () => ({
   entries: { note_id: 'note_id' },
 }));
 
-mock.module('react-native', () => ({
+jest.mock('react-native', () => ({
   Image: {
     getSize: (_uri: string, onSuccess: (width: number, height: number) => void) =>
       onSuccess(1, 1),
@@ -79,7 +80,7 @@ mock.module('react-native', () => ({
   Platform: { OS: 'ios' },
 }));
 
-mock.module('expo-file-system', () => ({
+jest.mock('expo-file-system', () => ({
   Directory: class MockDirectory {
     exists = true;
     create() {}
@@ -103,22 +104,22 @@ mock.module('expo-file-system', () => ({
   Paths: { document: '/tmp', cache: '/tmp' },
 }));
 
-mock.module('expo-sharing', () => ({
+jest.mock('expo-sharing', () => ({
   isAvailableAsync: async () => false,
   shareAsync: async () => undefined,
 }));
 
-mock.module('~/lib/photoUtils', () => ({
+jest.mock('~/lib/photoUtils', () => ({
   deletePhotoFile: () => {},
   photoFileExists: () => true,
 }));
 
-mock.module('~/lib/voiceMemoUtils', () => ({
+jest.mock('~/lib/voiceMemoUtils', () => ({
   deleteVoiceMemoFile: () => {},
   voiceMemoFileExists: () => true,
 }));
 
-const archiveUtilsMockFactory = () => ({
+jest.mock('../archiveUtils', () => ({
   VALID_MOODS: new Set(['Joyful', 'Calm', 'Neutral', 'Anxious', 'Sad', 'Angry']),
   generateTimestamp: () => '2026-04-22T10-00-00',
   normalizeOptionalText: (value: string | null | undefined) => {
@@ -126,7 +127,8 @@ const archiveUtilsMockFactory = () => ({
     return trimmed ? trimmed : null;
   },
   assertSafeArchivePath: (path: string) => path,
-  cleanupImportedFiles: (relativeUris: string[]) => mockCleanupImportedFiles(relativeUris),
+  cleanupImportedFiles: (relativeUris: string[]) =>
+    mockCleanupImportedFiles(relativeUris),
   writeImportedAudio: (_bytes: Uint8Array, _path: string) => ({
     type: 'AUDIO',
     uri: 'voice-memos/mock.m4a',
@@ -140,7 +142,8 @@ const archiveUtilsMockFactory = () => ({
   buildTagIdToNameMap: async () => new Map(),
   resolveTagIdsToTitles: (_tagIds: string, _tagMap: Map<string, string>) => [],
   getRelativeAssetFile: (_relativeUri: string) => null,
-  createArchiveAssetPath: (_type: string, relativeUri: string) => `media/photos/${relativeUri}`,
+  createArchiveAssetPath: (_type: string, relativeUri: string) =>
+    `media/photos/${relativeUri}`,
   assetFileExists: (_asset: unknown) => true,
   buildSubstantiveCheck: ({
     textTitle,
@@ -169,13 +172,11 @@ const archiveUtilsMockFactory = () => ({
 
     return firstLine ? firstLine.slice(0, 120) : null;
   },
-  writeImportedPhoto: (bytes: Uint8Array, path: string) => mockWriteImportedPhoto(bytes, path),
-});
+  writeImportedPhoto: (bytes: Uint8Array, path: string) =>
+    mockWriteImportedPhoto(bytes, path),
+}));
 
-mock.module('../archiveUtils', archiveUtilsMockFactory);
-mock.module('../archiveUtils.ts', archiveUtilsMockFactory);
-
-const portableMockFactory = () => ({
+jest.mock('../portable', () => ({
   ensurePortablePromptTitles: (
     txArg: unknown,
     portablePromptsArg: unknown,
@@ -205,30 +206,20 @@ const portableMockFactory = () => ({
     ),
   upsertPortableTags: (txArg: unknown, portableTagsArg: unknown, summaryArg: unknown) =>
     mockUpsertPortableTags(txArg, portableTagsArg, summaryArg),
-});
+}));
 
-mock.module('../portable', portableMockFactory);
-mock.module('../portable.ts', portableMockFactory);
-
-const helpersMockFactory = () => ({
+jest.mock('./helpers', () => ({
   applyImportedProfile: (profileArg: unknown, imageUriArg: string | null) =>
     mockApplyImportedProfile(profileArg, imageUriArg),
   getImportTotals: (...args: Parameters<typeof mockGetImportTotals>) =>
     mockGetImportTotals(...args),
-});
+}));
 
-mock.module('./helpers', helpersMockFactory);
-mock.module('./helpers.ts', helpersMockFactory);
-
-mock.module('../progress', () => ({
-  reportImportProgress: mock(() => {}),
+jest.mock('../progress', () => ({
+  reportImportProgress: jest.fn(() => {}),
 }));
 
 describe('importFromTackbokBackup', () => {
-  beforeAll(async () => {
-    ({ importFromTackbokBackup } = await import('./tackbok'));
-  });
-
   beforeEach(() => {
     txSelectFrom.mockReset();
     txSelect.mockReset();
@@ -252,14 +243,18 @@ describe('importFromTackbokBackup', () => {
     );
     mockIsZipFile.mockReturnValue(true);
     mockLoadZipFromUri.mockResolvedValue({
-      close: mock(async () => undefined),
+      close: jest.fn(async () => undefined),
     });
     mockReadSafeZipJson
       .mockResolvedValueOnce({ format: 'tackbok-backup', backupVersion: 1 })
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce({ name: 'Ada', email: null, imagePath: 'media/profile.jpg' });
+      .mockResolvedValueOnce({
+        name: 'Ada',
+        email: null,
+        imagePath: 'media/profile.jpg',
+      });
     mockReadSafeZipBytes.mockResolvedValue(new Uint8Array([1, 2, 3]));
     mockWriteImportedPhoto.mockRejectedValue(new Error('corrupt profile image'));
     mockUpsertPortableTags.mockResolvedValue(new Map());
@@ -313,9 +308,5 @@ describe('importFromTackbokBackup', () => {
     );
 
     warnSpy.mockRestore();
-  });
-
-  afterAll(() => {
-    mock.restore();
   });
 });

--- a/apps/mobile/src/lib/backupImport/portable.test.ts
+++ b/apps/mobile/src/lib/backupImport/portable.test.ts
@@ -1,28 +1,18 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  spyOn,
-  test,
-} from 'bun:test';
 import type { ZipEntryInfo, ZipReader } from '~/lib/zip';
 import { AssetType, type Asset } from '~/types';
+import {
+  buildGratitudeAppPortablePayload,
+  importPortableEntries,
+  upsertPortableTags,
+} from './portable';
 import { createBackupImportSummary } from './summary';
 
-type PortableModule = typeof import('./portable');
+const spyOn = jest.spyOn;
 
-let buildGratitudeAppPortablePayload: PortableModule['buildGratitudeAppPortablePayload'];
-let importPortableEntries: PortableModule['importPortableEntries'];
-let upsertPortableTags: PortableModule['upsertPortableTags'];
-
-const mockReadSafeZipBytes = mock(
+const mockReadSafeZipBytes = jest.fn(
   async (_zip: ZipReader, _path: string) => new Uint8Array(),
 );
-const mockWriteImportedPhoto = mock(
+const mockWriteImportedPhoto = jest.fn(
   async (_bytes: Uint8Array, _path: string): Promise<Asset> => ({
     type: AssetType.IMAGE,
     uri: 'photos/imported.jpg',
@@ -30,22 +20,22 @@ const mockWriteImportedPhoto = mock(
     height: 10,
   }),
 );
-const mockWriteImportedAudio = mock(
+const mockWriteImportedAudio = jest.fn(
   (_bytes: Uint8Array, _path: string): Asset => ({
     type: AssetType.AUDIO,
     uri: 'voice-memos/imported.m4a',
   }),
 );
-const mockCleanupImportedFiles = mock((_relativeUris: string[]): void => {});
+const mockCleanupImportedFiles = jest.fn((_relativeUris: string[]): void => {});
 
-mock.module('~/db', () => ({
+jest.mock('~/db', () => ({
   db: {},
   customPrompts: {},
   entries: { note_id: 'note_id' },
   tags: {},
 }));
 
-mock.module('react-native', () => ({
+jest.mock('react-native', () => ({
   Image: {
     getSize: (_uri: string, onSuccess: (width: number, height: number) => void) =>
       onSuccess(1, 1),
@@ -53,7 +43,7 @@ mock.module('react-native', () => ({
   Platform: { OS: 'ios' },
 }));
 
-mock.module('expo-file-system', () => ({
+jest.mock('expo-file-system', () => ({
   Directory: class MockDirectory {
     exists = true;
     create() {}
@@ -77,22 +67,22 @@ mock.module('expo-file-system', () => ({
   Paths: { document: '/tmp', cache: '/tmp' },
 }));
 
-mock.module('expo-sharing', () => ({
+jest.mock('expo-sharing', () => ({
   isAvailableAsync: async () => false,
   shareAsync: async () => undefined,
 }));
 
-mock.module('~/lib/photoUtils', () => ({
+jest.mock('~/lib/photoUtils', () => ({
   deletePhotoFile: () => {},
   photoFileExists: () => true,
 }));
 
-mock.module('~/lib/voiceMemoUtils', () => ({
+jest.mock('~/lib/voiceMemoUtils', () => ({
   deleteVoiceMemoFile: () => {},
   voiceMemoFileExists: () => true,
 }));
 
-const archiveUtilsMockFactory = () => ({
+jest.mock('./archiveUtils', () => ({
   VALID_MOODS: new Set(['Joyful', 'Calm', 'Neutral', 'Anxious', 'Sad', 'Angry']),
   generateTimestamp: () => '2026-04-22T10-00-00',
   normalizeOptionalText: (value: string | null | undefined) => {
@@ -121,7 +111,7 @@ const archiveUtilsMockFactory = () => ({
   saveGeneratedZipFile: async (_file: unknown, _fileName: string) => {},
   readSafeZipJson: <T>(zip: ZipReader, path: string) => zip.readEntryJson<T>(path),
   readSafeZipBytes: (zip: ZipReader, path: string) => mockReadSafeZipBytes(zip, path),
-  loadZipFromUri: async (_uri: string) => createFakeStreamingZipArchive({}),
+  loadZipFromUri: async (_uri: string) => mockCreateFakeStreamingZipArchive({}),
   isZipFile: (_uri: string) => true,
   buildTagIdToNameMap: async () => new Map(),
   resolveTagIdsToTitles: (_tagIds: string, _tagMap: Map<string, string>) => [],
@@ -145,12 +135,9 @@ const archiveUtilsMockFactory = () => ({
 
     return firstLine ? firstLine.slice(0, 120) : null;
   },
-});
+}));
 
-mock.module('./archiveUtils', archiveUtilsMockFactory);
-mock.module('./archiveUtils.ts', archiveUtilsMockFactory);
-
-function createFakeStreamingZipArchive(
+function mockCreateFakeStreamingZipArchive(
   entries: Record<string, string | Uint8Array>,
 ): ZipReader {
   const byteEntries = new Map(
@@ -211,13 +198,13 @@ function createFakeStreamingZipArchive(
 }
 
 function createTransactionMock() {
-  const limit = mock(async (_count?: number): Promise<{ note_id: string }[]> => []);
-  const where = mock(() => ({ limit }));
-  const from = mock(() => ({ where, limit }));
-  const select = mock(() => ({ from }));
-  const onConflictDoUpdate = mock(async (_value: unknown): Promise<void> => {});
-  const values = mock(() => ({ onConflictDoUpdate }));
-  const insert = mock(() => ({ values }));
+  const limit = jest.fn(async (_count?: number): Promise<{ note_id: string }[]> => []);
+  const where = jest.fn(() => ({ limit }));
+  const from = jest.fn(() => ({ where, limit }));
+  const select = jest.fn(() => ({ from }));
+  const onConflictDoUpdate = jest.fn(async (_value: unknown): Promise<void> => {});
+  const values = jest.fn(() => ({ onConflictDoUpdate }));
+  const insert = jest.fn(() => ({ values }));
 
   return {
     tx: { insert, select },
@@ -231,13 +218,6 @@ function createTransactionMock() {
   };
 }
 
-beforeAll(async () => {
-  const portableModule = await import('./portable');
-  buildGratitudeAppPortablePayload = portableModule.buildGratitudeAppPortablePayload;
-  importPortableEntries = portableModule.importPortableEntries;
-  upsertPortableTags = portableModule.upsertPortableTags;
-});
-
 beforeEach(() => {
   mockReadSafeZipBytes.mockReset();
   mockWriteImportedPhoto.mockReset();
@@ -247,7 +227,7 @@ beforeEach(() => {
 
 describe('buildGratitudeAppPortablePayload', () => {
   test('resolves Gratitude media entries by basename when the zip has a parent folder', async () => {
-    const zip = createFakeStreamingZipArchive({
+    const zip = mockCreateFakeStreamingZipArchive({
       'gratitudeEntries.json': JSON.stringify([
         {
           noteId: 'entry-1',
@@ -330,7 +310,7 @@ describe('importPortableEntries', () => {
       new Map(),
       summary,
       'overwrite',
-      createFakeStreamingZipArchive({}),
+      mockCreateFakeStreamingZipArchive({}),
       createdFiles,
       'tackbok',
     );
@@ -382,7 +362,7 @@ describe('importPortableEntries', () => {
       new Map(),
       summary,
       'overwrite',
-      createFakeStreamingZipArchive({}),
+      mockCreateFakeStreamingZipArchive({}),
       [],
       'tackbok',
     );
@@ -431,7 +411,7 @@ describe('importPortableEntries', () => {
         new Map(),
         summary,
         'overwrite',
-        createFakeStreamingZipArchive({}),
+        mockCreateFakeStreamingZipArchive({}),
         [],
         'tackbok',
       ),
@@ -444,7 +424,7 @@ describe('importPortableEntries', () => {
 describe('upsertPortableTags', () => {
   test('reuses existing tags when portable titles normalize to the same key', async () => {
     const existingTagId = 'existing-tag-id';
-    const insertedValues = mock(async (_value: unknown): Promise<void> => {});
+    const insertedValues = jest.fn(async (_value: unknown): Promise<void> => {});
     const tx = {
       select: () => ({
         from: async () => [{ tag_id: existingTagId, title: 'Work,Focus' }],
@@ -465,8 +445,4 @@ describe('upsertPortableTags', () => {
     expect(tagMap.get('work focus')).toBe(existingTagId);
     expect(summary.importedTags).toBe(0);
   });
-});
-
-afterAll(() => {
-  mock.restore();
 });

--- a/apps/mobile/src/lib/theme/typography.test.ts
+++ b/apps/mobile/src/lib/theme/typography.test.ts
@@ -1,0 +1,73 @@
+import { Uniwind } from 'uniwind';
+import {
+  BODY_FONT_SIZES,
+  DEFAULT_BODY_FONT_SIZE,
+  DEFAULT_TITLE_FONT_SELECTION,
+  TITLE_FONTS,
+  applyTitleFont,
+  getThemeDefaultTitleFontId,
+  getTitleFont,
+  normalizeBodyFontSize,
+  normalizeTitleFontSelection,
+} from './typography';
+import { THEMES } from './registry';
+
+jest.mock('uniwind', () => ({
+  Uniwind: {
+    updateCSSVariables: jest.fn(),
+  },
+}));
+
+const updateCSSVariablesMock = jest.mocked(Uniwind.updateCSSVariables);
+
+describe('typography normalization', () => {
+  beforeEach(() => {
+    updateCSSVariablesMock.mockClear();
+  });
+
+  test('normalizeTitleFontSelection falls back to default for invalid values', () => {
+    expect(normalizeTitleFontSelection(undefined)).toBe(DEFAULT_TITLE_FONT_SELECTION);
+    expect(normalizeTitleFontSelection(null)).toBe(DEFAULT_TITLE_FONT_SELECTION);
+    expect(normalizeTitleFontSelection('not-a-font')).toBe(DEFAULT_TITLE_FONT_SELECTION);
+  });
+
+  test('normalizeBodyFontSize keeps known sizes', () => {
+    for (const size of BODY_FONT_SIZES) {
+      expect(normalizeBodyFontSize(size)).toBe(size);
+    }
+  });
+
+  test('normalizeBodyFontSize falls back to default for stale values', () => {
+    expect(normalizeBodyFontSize(undefined)).toBe(DEFAULT_BODY_FONT_SIZE);
+    expect(normalizeBodyFontSize(null)).toBe(DEFAULT_BODY_FONT_SIZE);
+    expect(normalizeBodyFontSize('huge')).toBe(DEFAULT_BODY_FONT_SIZE);
+  });
+
+  test('applyTitleFont preserves each theme default when selection is default', () => {
+    applyTitleFont(DEFAULT_TITLE_FONT_SELECTION);
+
+    expect(updateCSSVariablesMock).toHaveBeenCalledTimes(THEMES.length);
+
+    for (const theme of THEMES) {
+      expect(updateCSSVariablesMock).toHaveBeenCalledWith(theme.id, {
+        '--font-heading': getTitleFont(getThemeDefaultTitleFontId(theme.id)).fontFamily,
+      });
+    }
+  });
+
+  test('applyTitleFont applies explicit font selection to all themes', () => {
+    const explicitFontId = TITLE_FONTS.find(
+      (font) => font.id !== getThemeDefaultTitleFontId(THEMES[0]!.id),
+    )!.id;
+
+    applyTitleFont(explicitFontId);
+
+    expect(updateCSSVariablesMock).toHaveBeenCalledTimes(THEMES.length);
+
+    for (const theme of THEMES) {
+      expect(updateCSSVariablesMock).toHaveBeenCalledWith(theme.id, {
+        '--font-heading': getTitleFont(explicitFontId).fontFamily,
+      });
+    }
+  });
+});


### PR DESCRIPTION
- Replaced Bun's built-in test runner with Jest to standardize testing architecture and improve mocking capabilities.
- Added global Jest mocks for `react-native` and `expo-file-system`.
- Updated `package.json` test scripts and dependencies.
- Migrated existing backup/export/import test suites to be fully compatible with Jest.