### PR TITLE
feat(ux): implement draggable and expanding Gratitude Action Dock

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -38,6 +38,7 @@
     "expo-document-picker": "~55.0.8",
     "expo-file-system": "~55.0.10",
     "expo-font": "~55.0.4",
+    "expo-haptics": "~55.0.14",
     "expo-image-manipulator": "~55.0.10",
     "expo-image-picker": "~55.0.12",
     "expo-linking": "~55.0.7",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,6 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web",
     "generate:themes": "bun run src/lib/theme/generate-theme-artifacts.ts",
     "generate:themes:verify": "bun run generate:themes && bun run test:theme",
     "lint": "expo lint",

--- a/apps/mobile/src/hooks/useGratitudeActionDockDrag.ts
+++ b/apps/mobile/src/hooks/useGratitudeActionDockDrag.ts
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type LayoutChangeEvent, type ViewStyle } from 'react-native';
+import {
+  Extrapolation,
+  interpolate,
+  type SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
+import { Gesture } from 'react-native-gesture-handler';
+import { scheduleOnRN } from 'react-native-worklets';
+import * as Haptics from 'expo-haptics';
+import { useSettingsStore } from '~/lib/settings/store';
+import type { GratitudeActionDockConfig } from '~/screens/home/GratitudeActionDock';
+
+interface UseGratitudeActionDockDragOptions {
+  dockConfig: GratitudeActionDockConfig;
+  isExpanded: boolean;
+  isRTL: boolean;
+  onToggle: () => void;
+}
+
+type DockAnimatedStyle = ReturnType<typeof useAnimatedStyle<ViewStyle>>;
+
+interface UseGratitudeActionDockDragResult {
+  /** Animated inner panel shape and borders for docked vs detached states. */
+  containerStyle: DockAnimatedStyle;
+  /** Measures the available vertical space so drag bounds can be clamped correctly. */
+  onContainerLayout: (e: LayoutChangeEvent) => void;
+  /** Long-press pan gesture that detaches the dock, tracks vertical drag, and snaps back on release. */
+  panGesture: ReturnType<typeof Gesture.Pan>;
+  /** Shared expand progress from 0 collapsed to 1 expanded, consumed by child animations. */
+  progress: SharedValue<number>;
+  /** Animated outer shell width, corner radius, and expansion shift. */
+  shellShadowStyle: DockAnimatedStyle;
+  /** Animated absolute positioning for the whole dock, including drag float and active scale. */
+  wrapperStyle: DockAnimatedStyle;
+}
+
+/**
+ * Owns the dock's drag lifecycle, persisted vertical position, and outer shell animation.
+ */
+export function useGratitudeActionDockDrag({
+  dockConfig,
+  isExpanded,
+  isRTL,
+  onToggle,
+}: UseGratitudeActionDockDragOptions): UseGratitudeActionDockDragResult {
+  const { animation, dimensions, gesture } = dockConfig;
+  const persistedY = useSettingsStore((s) => s.actionDockY);
+  const setPersistedY = useSettingsStore((s) => s.setActionDockY);
+
+  const [containerHeight, setContainerHeight] = useState(0);
+
+  const onContainerLayout = useCallback((e: LayoutChangeEvent) => {
+    setContainerHeight(e.nativeEvent.layout.height);
+  }, []);
+
+  const minY = gesture.verticalPadding;
+  const maxY = Math.max(
+    minY,
+    containerHeight - dimensions.panelHeight - gesture.verticalPadding,
+  );
+  const defaultY = Math.max(minY, Math.round(containerHeight * 0.7));
+  const inwardFloatX = isRTL
+    ? animation.inwardFloatOffsetX
+    : -animation.inwardFloatOffsetX;
+  const expandedShellShiftX = isRTL
+    ? animation.expandedShellShiftX
+    : -animation.expandedShellShiftX;
+
+  const clampY = useCallback(
+    (y: number) => {
+      'worklet';
+      return Math.min(maxY, Math.max(minY, y));
+    },
+    [minY, maxY],
+  );
+
+  const progress = useSharedValue(isExpanded ? 1 : 0);
+  const positionY = useSharedValue(clampY(persistedY ?? defaultY));
+  const floatX = useSharedValue(0);
+  const dragScale = useSharedValue(1);
+  const isDragging = useSharedValue(false);
+  const dragStartY = useSharedValue(0);
+
+  useEffect(() => {
+    progress.value = withSpring(isExpanded ? 1 : 0, animation.spring);
+  }, [animation.spring, isExpanded, progress]);
+
+  useEffect(() => {
+    if (containerHeight > 0) {
+      const target = persistedY !== null ? clampY(persistedY) : clampY(defaultY);
+      positionY.value = target;
+    }
+  }, [clampY, containerHeight, defaultY, persistedY, positionY]);
+
+  const persistPosition = useCallback(
+    (y: number) => {
+      setPersistedY(Math.round(y));
+    },
+    [setPersistedY],
+  );
+
+  const triggerDragStartHaptic = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+  }, []);
+
+  const triggerDragEndHaptic = useCallback(() => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  }, []);
+
+  const finishDetachedDrag = useCallback(
+    (shouldTriggerHaptic: boolean) => {
+      'worklet';
+      if (!isDragging.value) return;
+
+      isDragging.value = false;
+      progress.value = withSpring(0, animation.spring);
+      floatX.value = withSpring(0, animation.snapSpring);
+      dragScale.value = withSpring(1, animation.snapSpring);
+      scheduleOnRN(persistPosition, positionY.value);
+
+      if (shouldTriggerHaptic) {
+        scheduleOnRN(triggerDragEndHaptic);
+      }
+    },
+    [
+      animation.snapSpring,
+      animation.spring,
+      dragScale,
+      floatX,
+      isDragging,
+      persistPosition,
+      positionY,
+      progress,
+      triggerDragEndHaptic,
+    ],
+  );
+
+  const startDetachedDrag = useCallback(() => {
+    'worklet';
+    if (progress.value > gesture.expandedProgressThreshold) {
+      progress.value = withSpring(0, animation.spring);
+      scheduleOnRN(onToggle);
+    }
+
+    isDragging.value = true;
+    dragStartY.value = positionY.value;
+    floatX.value = withSpring(inwardFloatX, animation.snapSpring);
+    dragScale.value = withSpring(animation.dragActiveScale, animation.snapSpring);
+    scheduleOnRN(triggerDragStartHaptic);
+  }, [
+    animation.dragActiveScale,
+    animation.snapSpring,
+    animation.spring,
+    dragScale,
+    dragStartY,
+    floatX,
+    gesture.expandedProgressThreshold,
+    inwardFloatX,
+    isDragging,
+    onToggle,
+    positionY,
+    progress,
+    triggerDragStartHaptic,
+  ]);
+
+  const panGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        // Keep the hold-to-drag interaction inside one recognizer.
+        // A separate LongPress + Pan pair made diagonal drags easy to cancel.
+        .activateAfterLongPress(gesture.longPressDurationMs)
+        .onStart(startDetachedDrag)
+        .onUpdate((e) => {
+          'worklet';
+          if (!isDragging.value) return;
+          const newY = dragStartY.value + e.translationY;
+          positionY.value = clampY(newY);
+        })
+        .onEnd(() => {
+          'worklet';
+          finishDetachedDrag(true);
+        })
+        .onFinalize(() => {
+          'worklet';
+          finishDetachedDrag(false);
+        }),
+    [
+      clampY,
+      dragStartY,
+      finishDetachedDrag,
+      gesture.longPressDurationMs,
+      isDragging,
+      positionY,
+      startDetachedDrag,
+    ],
+  );
+
+  const wrapperStyle = useAnimatedStyle(() => ({
+    top: positionY.value,
+    transform: [{ translateX: floatX.value }, { scale: dragScale.value }],
+  }));
+
+  const shellShadowStyle = useAnimatedStyle(() => {
+    const dragging = isDragging.value;
+    const detachedEdgeRadius = dragging ? dimensions.cornerRadius : 0;
+
+    return {
+      width: interpolate(
+        progress.value,
+        [0, 1],
+        [dimensions.tabWidth, dimensions.expandedWidth],
+        Extrapolation.CLAMP,
+      ),
+      height: dimensions.panelHeight,
+      transform: [
+        {
+          translateX: interpolate(
+            progress.value,
+            [0, 1],
+            [0, expandedShellShiftX],
+            Extrapolation.CLAMP,
+          ),
+        },
+      ],
+      // Keep physical left/right geometry in LTR terms here.
+      // React Native swaps these edge styles for RTL, so manual mirroring
+      // would double-flip the dock shell.
+      borderTopLeftRadius: dimensions.cornerRadius,
+      borderBottomLeftRadius: dimensions.cornerRadius,
+      borderTopRightRadius: detachedEdgeRadius,
+      borderBottomRightRadius: detachedEdgeRadius,
+    };
+  });
+
+  const containerStyle = useAnimatedStyle(() => {
+    const dragging = isDragging.value;
+    const detachedEdgeRadius = dragging ? dimensions.cornerRadius : 0;
+    const detachedEdgeBorderWidth = dragging ? 1 : 0;
+
+    return {
+      flex: 1,
+      borderTopLeftRadius: dimensions.cornerRadius,
+      borderBottomLeftRadius: dimensions.cornerRadius,
+      borderTopRightRadius: detachedEdgeRadius,
+      borderBottomRightRadius: detachedEdgeRadius,
+      borderLeftWidth: 1,
+      borderRightWidth: detachedEdgeBorderWidth,
+    };
+  });
+
+  return {
+    containerStyle,
+    onContainerLayout,
+    panGesture,
+    progress,
+    shellShadowStyle,
+    wrapperStyle,
+  };
+}

--- a/apps/mobile/src/hooks/useGratitudeActionDockPresentation.ts
+++ b/apps/mobile/src/hooks/useGratitudeActionDockPresentation.ts
@@ -14,7 +14,7 @@ import * as Haptics from 'expo-haptics';
 import { useSettingsStore } from '~/lib/settings/store';
 import type { GratitudeActionDockConfig } from '~/screens/home/GratitudeActionDock';
 
-interface UseGratitudeActionDockDragOptions {
+interface UseGratitudeActionDockPresentationOptions {
   dockConfig: GratitudeActionDockConfig;
   isExpanded: boolean;
   isRTL: boolean;
@@ -23,9 +23,14 @@ interface UseGratitudeActionDockDragOptions {
 
 type DockAnimatedStyle = ReturnType<typeof useAnimatedStyle<ViewStyle>>;
 
-interface UseGratitudeActionDockDragResult {
+interface UseGratitudeActionDockPresentationResult {
   /** Animated inner panel shape and borders for docked vs detached states. */
   containerStyle: DockAnimatedStyle;
+  /**
+   * True once the absolute-positioning container has been measured and the dock
+   * can render at its real persisted/default Y without a first-paint jump.
+   */
+  hasMeasured: boolean;
   /** Measures the available vertical space so drag bounds can be clamped correctly. */
   onContainerLayout: (e: LayoutChangeEvent) => void;
   /** Long-press pan gesture that detaches the dock, tracks vertical drag, and snaps back on release. */
@@ -39,19 +44,25 @@ interface UseGratitudeActionDockDragResult {
 }
 
 /**
- * Owns the dock's drag lifecycle, persisted vertical position, and outer shell animation.
+ * Builds the dock's animated presentation layer.
+ *
+ * This hook owns the dock's drag-to-reposition interaction, persisted vertical
+ * placement, haptics, and the animated styles that render the collapsed and
+ * expanded shell. It does not decide when the dock should expand or collapse
+ * from timeline scrolling; that policy lives in the scroll behavior hook.
  */
-export function useGratitudeActionDockDrag({
+export function useGratitudeActionDockPresentation({
   dockConfig,
   isExpanded,
   isRTL,
   onToggle,
-}: UseGratitudeActionDockDragOptions): UseGratitudeActionDockDragResult {
+}: UseGratitudeActionDockPresentationOptions): UseGratitudeActionDockPresentationResult {
   const { animation, dimensions, gesture } = dockConfig;
   const persistedY = useSettingsStore((s) => s.actionDockY);
   const setPersistedY = useSettingsStore((s) => s.setActionDockY);
 
   const [containerHeight, setContainerHeight] = useState(0);
+  const hasMeasured = containerHeight > 0;
 
   const onContainerLayout = useCallback((e: LayoutChangeEvent) => {
     setContainerHeight(e.nativeEvent.layout.height);
@@ -254,6 +265,7 @@ export function useGratitudeActionDockDrag({
 
   return {
     containerStyle,
+    hasMeasured,
     onContainerLayout,
     panGesture,
     progress,

--- a/apps/mobile/src/hooks/useGratitudeActionDockScrollBehavior.ts
+++ b/apps/mobile/src/hooks/useGratitudeActionDockScrollBehavior.ts
@@ -1,0 +1,106 @@
+import { useCallback, useRef, useState } from 'react';
+import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
+
+/** Downward distance required to hide the dock while reading through the timeline. */
+const SCROLL_COLLAPSE_THRESHOLD = 30;
+/** Upward distance required to reopen the dock after an auto-collapse. */
+const SCROLL_EXPAND_THRESHOLD = 48;
+
+type ScrollDirection = 'up' | 'down' | null;
+
+interface UseGratitudeActionDockScrollBehaviorResult {
+  /** Controlled dock state consumed by the home screen. */
+  isExpanded: boolean;
+  /** Manual dock toggle that opts out of immediate scroll-driven reopening. */
+  onToggle: () => void;
+  /** Resets cumulative tracking at the start of a fresh drag interaction. */
+  onScrollBeginDrag: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  /** Expands or collapses the dock from cumulative directional scroll distance. */
+  onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+}
+
+/**
+ * Applies scroll-driven expand/collapse rules for the gratitude action dock.
+ *
+ * The hook tracks cumulative scroll distance within the current direction,
+ * resets its baseline on direction changes, and uses separate thresholds for
+ * collapsing and reopening. Auto-expand is allowed only after a scroll-driven
+ * collapse so manual user toggles are not immediately undone by the next
+ * upward drag.
+ */
+export function useGratitudeActionDockScrollBehavior(): UseGratitudeActionDockScrollBehaviorResult {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const autoCollapsed = useRef(false);
+  const baselineScrollY = useRef(0);
+  const currentScrollY = useRef(0);
+  const lastDirection = useRef<ScrollDirection>(null);
+  const lastScrollY = useRef(0);
+
+  const resetScrollTracking = useCallback((scrollY: number) => {
+    const normalizedY = Math.max(0, scrollY);
+    baselineScrollY.current = normalizedY;
+    currentScrollY.current = normalizedY;
+    lastDirection.current = null;
+    lastScrollY.current = normalizedY;
+  }, []);
+
+  const handleScrollBeginDrag = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      resetScrollTracking(event.nativeEvent.contentOffset.y);
+    },
+    [resetScrollTracking],
+  );
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const currentY = Math.max(0, event.nativeEvent.contentOffset.y);
+      currentScrollY.current = currentY;
+
+      const deltaFromLast = currentY - lastScrollY.current;
+      if (deltaFromLast === 0) {
+        return;
+      }
+
+      const direction: ScrollDirection = deltaFromLast > 0 ? 'down' : 'up';
+      if (lastDirection.current !== direction) {
+        baselineScrollY.current = lastScrollY.current;
+        lastDirection.current = direction;
+      }
+
+      const distanceFromBaseline = currentY - baselineScrollY.current;
+
+      if (direction === 'down') {
+        if (isExpanded && distanceFromBaseline >= SCROLL_COLLAPSE_THRESHOLD) {
+          autoCollapsed.current = true;
+          setIsExpanded(false);
+          resetScrollTracking(currentY);
+        }
+      } else if (
+        !isExpanded &&
+        autoCollapsed.current &&
+        baselineScrollY.current - currentY >= SCROLL_EXPAND_THRESHOLD
+      ) {
+        autoCollapsed.current = false;
+        setIsExpanded(true);
+        resetScrollTracking(currentY);
+      }
+
+      lastScrollY.current = currentY;
+    },
+    [isExpanded, resetScrollTracking],
+  );
+
+  const handleToggle = useCallback(() => {
+    autoCollapsed.current = false;
+    setIsExpanded((prev) => !prev);
+    resetScrollTracking(currentScrollY.current);
+  }, [resetScrollTracking]);
+
+  return {
+    isExpanded,
+    onToggle: handleToggle,
+    onScroll: handleScroll,
+    onScrollBeginDrag: handleScrollBeginDrag,
+  };
+}

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -36,6 +36,10 @@ export const ar: Translations = {
   'What are you grateful for?': 'ما الذي تشعر بالامتنان له؟',
   'What were you grateful for?': 'ما الذي كنت ممتنًا له؟',
   'Failed to load entries': 'فشل تحميل السجلات',
+  'Write now': 'اكتب الآن',
+  'Pick a date': 'اختر تاريخًا',
+  'Collapse gratitude actions': 'طي إجراءات الامتنان',
+  'Expand gratitude actions': 'توسيع إجراءات الامتنان',
 
   // Date Entries
   'Loading...': 'جاري التحميل...',

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -429,6 +429,8 @@ export const ar: Translations = {
   'This action cannot be undone. All your app data will be permanently deleted.':
     'لا يمكن التراجع عن هذا الإجراء. سيتم حذف جميع بيانات التطبيق الخاصة بك بشكل دائم.',
   'All data deleted': 'تم حذف جميع البيانات',
+  'All data deleted, but some media files could not be removed.':
+    'تم حذف جميع البيانات، ولكن تعذر إزالة بعض ملفات الوسائط.',
   'Delete failed': 'فشل الحذف',
 
   // Time Picker

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -446,6 +446,8 @@ export const en = {
   'This action cannot be undone. All your app data will be permanently deleted.':
     'This action cannot be undone. All your app data will be permanently deleted.',
   'All data deleted': 'All data deleted',
+  'All data deleted, but some media files could not be removed.':
+    'All data deleted, but some media files could not be removed.',
   'Delete failed': 'Delete failed',
 
   // Time Picker

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -36,6 +36,10 @@ export const en = {
   'What are you grateful for?': 'What are you grateful for?',
   'What were you grateful for?': 'What were you grateful for?',
   'Failed to load entries': 'Failed to load entries',
+  'Write now': 'Write now',
+  'Pick a date': 'Pick a date',
+  'Collapse gratitude actions': 'Collapse gratitude actions',
+  'Expand gratitude actions': 'Expand gratitude actions',
 
   // Date Entries
   'Loading...': 'Loading...',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -37,6 +37,10 @@ export const he: Translations = {
   'What are you grateful for?': 'על מה אתה אסיר תודה?',
   'What were you grateful for?': 'על מה היית אסיר תודה?',
   'Failed to load entries': 'טעינת הרשומות נכשלה',
+  'Write now': 'כתוב עכשיו',
+  'Pick a date': 'בחר תאריך',
+  'Collapse gratitude actions': 'כווץ פעולות הודיה',
+  'Expand gratitude actions': 'הרחב פעולות הודיה',
 
   // Date Entries
   'Loading...': 'טוען...',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -429,6 +429,8 @@ export const he: Translations = {
   'This action cannot be undone. All your app data will be permanently deleted.':
     'לא ניתן לבטל פעולה זו. כל נתוני האפליקציה שלך יימחקו לצמיתות.',
   'All data deleted': 'כל הנתונים נמחקו',
+  'All data deleted, but some media files could not be removed.':
+    'כל הנתונים נמחקו, אך לא ניתן היה להסיר חלק מקובצי המדיה.',
   'Delete failed': 'המחיקה נכשלה',
 
   // Time Picker

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -36,6 +36,10 @@ export const zhCN: Translations = {
   'What are you grateful for?': '你有什么值得感恩的？',
   'What were you grateful for?': '你曾为什么感激？',
   'Failed to load entries': '加载条目失败',
+  'Write now': '现在写',
+  'Pick a date': '选择日期',
+  'Collapse gratitude actions': '收起感恩操作',
+  'Expand gratitude actions': '展开感恩操作',
 
   // Date Entries
   'Loading...': '加载中...',

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -417,6 +417,8 @@ export const zhCN: Translations = {
   'This action cannot be undone. All your app data will be permanently deleted.':
     '此操作无法撤销。您的所有应用数据将被永久删除。',
   'All data deleted': '所有数据已删除',
+  'All data deleted, but some media files could not be removed.':
+    '所有数据已删除，但部分媒体文件无法移除。',
   'Delete failed': '删除失败',
 
   // Time Picker

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -418,6 +418,8 @@ export const zhTW: Translations = {
   'This action cannot be undone. All your app data will be permanently deleted.':
     '此動作無法復原。您的所有應用程式資料將被永久刪除。',
   'All data deleted': '所有資料已刪除',
+  'All data deleted, but some media files could not be removed.':
+    '所有資料已刪除，但部分媒體檔案無法移除。',
   'Delete failed': '刪除失敗',
 
   // Time Picker

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -36,6 +36,10 @@ export const zhTW: Translations = {
   'What are you grateful for?': '您有什麼值得感恩的？',
   'What were you grateful for?': '您曾為什麼感恩？',
   'Failed to load entries': '無法載入紀錄',
+  'Write now': '現在寫',
+  'Pick a date': '選擇日期',
+  'Collapse gratitude actions': '收起感恩操作',
+  'Expand gratitude actions': '展開感恩操作',
 
   // Date Entries
   'Loading...': '載入中...',

--- a/apps/mobile/src/lib/settings/store.ts
+++ b/apps/mobile/src/lib/settings/store.ts
@@ -59,6 +59,10 @@ interface SettingsState {
   journalFocusAreas: BuiltInJournalPromptCategoryId[];
   journalPromptsMode: JournalPromptsMode;
 
+  // Layout
+  /** Persisted vertical position (top offset in px) for the action dock. null = default bottom. */
+  actionDockY: number | null;
+
   // Hydration status
   _hasHydrated: boolean;
 
@@ -82,35 +86,42 @@ interface SettingsState {
   setAnalyticsEnabled: (enabled: boolean) => void;
   setCustomWorksheetTemplate: (template: string | null) => void;
   resetCustomWorksheetTemplate: () => void;
+  resetToDefaults: () => void;
   setJournalFocusAreas: (areas: BuiltInJournalPromptCategoryId[]) => void;
   setJournalPromptsMode: (mode: JournalPromptsMode) => void;
+  setActionDockY: (y: number | null) => void;
   setHasHydrated: (hydrated: boolean) => void;
 }
+
+const DEFAULT_SETTINGS_VALUES = {
+  dailyReminderEnabled: false,
+  reminderTime: '09:00',
+  profileName: null,
+  profileEmail: null,
+  profileImageUri: null,
+  theme: DEFAULT_THEME_ID,
+  timelineEntryLength: 10,
+  inspirationalQuotesEnabled: true,
+  dateIncludesDayOfWeek: false,
+  firstDayOfWeek: FirstDay.MONDAY,
+  showTimelineBorders: false,
+  titleFont: DEFAULT_TITLE_FONT_SELECTION,
+  bodyFontSize: DEFAULT_BODY_FONT_SIZE,
+  biometricUnlockEnabled: false,
+  googleDriveBackupEnabled: false,
+  backupFrequency: 'daily' as const,
+  analyticsEnabled: false,
+  customWorksheetTemplate: null,
+  journalFocusAreas: DEFAULT_JOURNAL_FOCUS_AREAS,
+  journalPromptsMode: 'off' as const,
+  actionDockY: null,
+};
 
 export const useSettingsStore = create<SettingsState>()(
   persist(
     (set, get) => ({
       // Default values
-      dailyReminderEnabled: false,
-      reminderTime: '09:00',
-      profileName: null,
-      profileEmail: null,
-      profileImageUri: null,
-      theme: DEFAULT_THEME_ID,
-      timelineEntryLength: 10,
-      inspirationalQuotesEnabled: true,
-      dateIncludesDayOfWeek: false,
-      firstDayOfWeek: FirstDay.MONDAY,
-      showTimelineBorders: false,
-      titleFont: DEFAULT_TITLE_FONT_SELECTION,
-      bodyFontSize: DEFAULT_BODY_FONT_SIZE,
-      biometricUnlockEnabled: false,
-      googleDriveBackupEnabled: false,
-      backupFrequency: 'daily',
-      analyticsEnabled: false,
-      customWorksheetTemplate: null,
-      journalFocusAreas: DEFAULT_JOURNAL_FOCUS_AREAS,
-      journalPromptsMode: 'off',
+      ...DEFAULT_SETTINGS_VALUES,
       _hasHydrated: false,
 
       // Actions
@@ -150,8 +161,14 @@ export const useSettingsStore = create<SettingsState>()(
       setCustomWorksheetTemplate: (template) =>
         set({ customWorksheetTemplate: template?.trim() ? template : null }),
       resetCustomWorksheetTemplate: () => set({ customWorksheetTemplate: null }),
+      resetToDefaults: () => {
+        Uniwind.setTheme(DEFAULT_SETTINGS_VALUES.theme);
+        applyTitleFont(DEFAULT_SETTINGS_VALUES.titleFont);
+        set({ ...DEFAULT_SETTINGS_VALUES });
+      },
       setJournalFocusAreas: (areas) => set({ journalFocusAreas: areas }),
       setJournalPromptsMode: (mode) => set({ journalPromptsMode: mode }),
+      setActionDockY: (y) => set({ actionDockY: y }),
       setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),
     }),
     {
@@ -205,6 +222,7 @@ export const useSettingsStore = create<SettingsState>()(
         customWorksheetTemplate: state.customWorksheetTemplate,
         journalFocusAreas: state.journalFocusAreas,
         journalPromptsMode: state.journalPromptsMode,
+        actionDockY: state.actionDockY,
       }),
     },
   ),

--- a/apps/mobile/src/screens/home/GratitudeActionDock.tsx
+++ b/apps/mobile/src/screens/home/GratitudeActionDock.tsx
@@ -11,7 +11,7 @@ import { cn } from 'tailwind-variants';
 import { Icon } from '~/components/ui/icon';
 import { useTranslation } from '~/lib/i18n';
 import { Button } from '~/components/ui/button';
-import { useGratitudeActionDockDrag } from '~/hooks/useGratitudeActionDockDrag';
+import { useGratitudeActionDockPresentation } from '~/hooks/useGratitudeActionDockPresentation';
 
 export const GRATITUDE_ACTION_DOCK_CONFIG = {
   dimensions: {
@@ -114,12 +114,13 @@ export function GratitudeActionDock({
   const { t, isRTL } = useTranslation();
   const {
     containerStyle,
+    hasMeasured,
     onContainerLayout,
     panGesture,
     progress,
     shellShadowStyle,
     wrapperStyle,
-  } = useGratitudeActionDockDrag({
+  } = useGratitudeActionDockPresentation({
       dockConfig: GRATITUDE_ACTION_DOCK_CONFIG,
       isExpanded,
       isRTL,
@@ -189,7 +190,7 @@ export function GratitudeActionDock({
       className="absolute inset-0"
       onLayout={onContainerLayout}>
       <Animated.View
-        style={wrapperStyle}
+        style={[wrapperStyle, { opacity: hasMeasured ? 1 : 0 }]}
         className={cn('absolute z-10', 'right-0 items-end')}>
         <GestureDetector gesture={panGesture}>
           <Animated.View

--- a/apps/mobile/src/screens/home/GratitudeActionDock.tsx
+++ b/apps/mobile/src/screens/home/GratitudeActionDock.tsx
@@ -1,0 +1,273 @@
+import React, { type ReactNode } from 'react';
+import { Pressable, View } from 'react-native';
+import Animated, {
+  Extrapolation,
+  interpolate,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+import { GestureDetector } from 'react-native-gesture-handler';
+import { Calendar, ChevronLeft, ChevronRight, Plus } from 'lucide-react-native';
+import { cn } from 'tailwind-variants';
+import { Icon } from '~/components/ui/icon';
+import { useTranslation } from '~/lib/i18n';
+import { Button } from '~/components/ui/button';
+import { useGratitudeActionDockDrag } from '~/hooks/useGratitudeActionDockDrag';
+
+export const GRATITUDE_ACTION_DOCK_CONFIG = {
+  dimensions: {
+    actionSize: 52,
+    panelHeight: 148,
+    tabWidth: 28,
+    expandedWidth: 102,
+    cornerRadius: 28,
+  },
+  gesture: {
+    verticalPadding: 16,
+    longPressDurationMs: 350,
+    expandedProgressThreshold: 0.1,
+  },
+  animation: {
+    spring: {
+      damping: 18,
+      stiffness: 200,
+      mass: 0.8,
+    },
+    snapSpring: {
+      damping: 22,
+      stiffness: 280,
+      mass: 0.6,
+    },
+    // Horizontal offset applied while the dock is detached during drag.
+    inwardFloatOffsetX: 14,
+    // Temporary scale bump while the user is actively dragging.
+    dragActiveScale: 1.08,
+    // Small shell nudge that keeps the expanded state feeling anchored to the edge.
+    expandedShellShiftX: 2,
+    // Entry offset for the action buttons as they slide into view.
+    actionsEntranceShiftX: 12,
+    // Travel distance for the chevron as the dock toggles.
+    chevronShiftX: 6,
+  },
+  icon: {
+    strokeWidth: 2.6,
+  },
+} as const;
+
+export type GratitudeActionDockConfig = typeof GRATITUDE_ACTION_DOCK_CONFIG;
+
+// ─── Sub-components ─────────────────────────────────────────────────
+interface DockActionButtonProps {
+  accessibilityLabel: string;
+  disabled: boolean;
+  onPress: () => void;
+  children: ReactNode;
+}
+
+function DockActionButton({
+  accessibilityLabel,
+  disabled,
+  onPress,
+  children,
+}: DockActionButtonProps) {
+  return (
+    <Button
+      size="icon"
+      variant="ghost"
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      className={cn(
+        'items-center justify-center rounded-full border border-border bg-background',
+        'active:opacity-80 shadow-theme',
+      )}
+      style={{
+        width: GRATITUDE_ACTION_DOCK_CONFIG.dimensions.actionSize,
+        height: GRATITUDE_ACTION_DOCK_CONFIG.dimensions.actionSize,
+      }}>
+      {children}
+    </Button>
+  );
+}
+
+// ─── Main component ─────────────────────────────────────────────────
+interface GratitudeActionDockProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+  onAddEntry: () => void;
+  onPickDate: () => void;
+}
+
+/**
+ * Right-docked journal action launcher for the home timeline.
+ *
+ * Supports drag-to-reposition: long-press the collapsed dock to detach it
+ * from the right edge, drag vertically, and release to snap back.
+ * The vertical position persists across restarts via the settings store.
+ */
+export function GratitudeActionDock({
+  isExpanded,
+  onToggle,
+  onAddEntry,
+  onPickDate,
+}: GratitudeActionDockProps) {
+  const { t, isRTL } = useTranslation();
+  const {
+    containerStyle,
+    onContainerLayout,
+    panGesture,
+    progress,
+    shellShadowStyle,
+    wrapperStyle,
+  } = useGratitudeActionDockDrag({
+      dockConfig: GRATITUDE_ACTION_DOCK_CONFIG,
+      isExpanded,
+      isRTL,
+      onToggle,
+    });
+  const directionMultiplier = isRTL ? -1 : 1;
+  const collapsedChevronIcon = isRTL ? ChevronRight : ChevronLeft;
+  const expandedChevronIcon = isRTL ? ChevronLeft : ChevronRight;
+
+  // ── Animated styles ─────────────────────────────────────────────
+  const actionsStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(progress.value, [0, 0.35, 1], [0, 0, 1], Extrapolation.CLAMP),
+    transform: [
+      {
+        translateX: interpolate(
+          progress.value,
+          [0, 1],
+          [
+            GRATITUDE_ACTION_DOCK_CONFIG.animation.actionsEntranceShiftX *
+              directionMultiplier,
+            0,
+          ],
+          Extrapolation.CLAMP,
+        ),
+      },
+    ],
+  }));
+
+  const collapsedChevronStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(progress.value, [0, 0.2, 0.45], [1, 1, 0], Extrapolation.CLAMP),
+    transform: [
+      {
+        translateX: interpolate(
+          progress.value,
+          [0, 1],
+          [
+            0,
+            -GRATITUDE_ACTION_DOCK_CONFIG.animation.chevronShiftX * directionMultiplier,
+          ],
+          Extrapolation.CLAMP,
+        ),
+      },
+    ],
+  }));
+
+  const expandedChevronStyle = useAnimatedStyle(() => ({
+    opacity: interpolate(progress.value, [0.4, 0.7, 1], [0, 0.8, 1], Extrapolation.CLAMP),
+    transform: [
+      {
+        translateX: interpolate(
+          progress.value,
+          [0, 1],
+          [GRATITUDE_ACTION_DOCK_CONFIG.animation.chevronShiftX * directionMultiplier, 0],
+          Extrapolation.CLAMP,
+        ),
+      },
+    ],
+  }));
+
+  const toggleAccessibilityLabel = isExpanded
+    ? t('Collapse gratitude actions')
+    : t('Expand gratitude actions');
+
+  return (
+    <View
+      pointerEvents="box-none"
+      className="absolute inset-0"
+      onLayout={onContainerLayout}>
+      <Animated.View
+        style={wrapperStyle}
+        className={cn('absolute z-10', 'right-0 items-end')}>
+        <GestureDetector gesture={panGesture}>
+          <Animated.View
+            style={shellShadowStyle}
+            className="shadow-theme">
+            <Animated.View
+              style={containerStyle}
+              className={cn(
+                'flex-row items-center overflow-hidden border border-border bg-muted',
+              )}>
+              {/* Action buttons – absolutely positioned so they never push
+                  the toggle tab out of the collapsed container */}
+              <Animated.View
+                pointerEvents={isExpanded ? 'auto' : 'none'}
+                style={[
+                  actionsStyle,
+                  {
+                    width:
+                      GRATITUDE_ACTION_DOCK_CONFIG.dimensions.expandedWidth -
+                      GRATITUDE_ACTION_DOCK_CONFIG.dimensions.tabWidth,
+                  },
+                ]}
+                className={cn(
+                  'absolute top-0 bottom-0 items-center justify-center gap-3 px-3',
+                  'left-0',
+                )}>
+                <DockActionButton
+                  accessibilityLabel={t('Write now')}
+                  disabled={!isExpanded}
+                  onPress={onAddEntry}>
+                  <View className="size-10 items-center justify-center rounded-full">
+                    <Icon as={Plus} className="text-primary-foreground" />
+                  </View>
+                </DockActionButton>
+
+                <DockActionButton
+                  accessibilityLabel={t('Pick a date')}
+                  disabled={!isExpanded}
+                  onPress={onPickDate}>
+                  <View className="size-10 items-center justify-center rounded-full">
+                    <Icon as={Calendar} className="text-primary-foreground" />
+                  </View>
+                </DockActionButton>
+              </Animated.View>
+
+              {/* Toggle chevron stays pinned to the docked edge in both LTR and RTL. */}
+              <Pressable
+                onPress={onToggle}
+                accessibilityRole="button"
+                accessibilityLabel={toggleAccessibilityLabel}
+                style={{ width: GRATITUDE_ACTION_DOCK_CONFIG.dimensions.tabWidth }}
+                className={cn(
+                  'relative h-full items-center justify-center bg-primary active:opacity-80',
+                  'ml-auto border-l border-border/70',
+                )}>
+                <Animated.View
+                  style={collapsedChevronStyle}
+                  className="absolute inset-0 items-center justify-center">
+                  <Icon
+                    as={collapsedChevronIcon}
+                    className="text-foreground size-5"
+                    strokeWidth={GRATITUDE_ACTION_DOCK_CONFIG.icon.strokeWidth}
+                  />
+                </Animated.View>
+                <Animated.View
+                  style={expandedChevronStyle}
+                  className="absolute inset-0 items-center justify-center">
+                  <Icon
+                    as={expandedChevronIcon}
+                    className="text-foreground size-5"
+                    strokeWidth={GRATITUDE_ACTION_DOCK_CONFIG.icon.strokeWidth}
+                  />
+                </Animated.View>
+              </Pressable>
+            </Animated.View>
+          </Animated.View>
+        </GestureDetector>
+      </Animated.View>
+    </View>
+  );
+}

--- a/apps/mobile/src/screens/home/GratitudeTimeline.tsx
+++ b/apps/mobile/src/screens/home/GratitudeTimeline.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import type { NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
 import { View } from 'react-native';
 import { format, subDays, startOfDay } from 'date-fns';
 import { LegendList } from '@legendapp/list';
@@ -19,6 +20,7 @@ import { GratitudeMilestone, isMilestone } from './GratitudeMilestone';
 interface IGratitudeTimelineProps {
   onEntryPress: (entry: Entry) => void;
   onAddEntry?: (dateMs: number) => void;
+  onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 }
 
 const EMPTY_GROUPS = new Map<number, Entry[]>();
@@ -36,6 +38,7 @@ function isDayGroupItem(item: TimelineListItem): item is DayGroup {
 export const GratitudeTimeline: React.FC<IGratitudeTimelineProps> = ({
   onEntryPress,
   onAddEntry,
+  onScroll,
 }) => {
   const { t } = useTranslation();
   const today = startOfDay(new Date());
@@ -224,6 +227,8 @@ export const GratitudeTimeline: React.FC<IGratitudeTimelineProps> = ({
         }
         ListFooterComponent={<View className="h-8" />}
         contentContainerClassName="pb-4"
+        onScroll={onScroll}
+        scrollEventThrottle={16}
       />
     </View>
   );

--- a/apps/mobile/src/screens/home/GratitudeTimeline.tsx
+++ b/apps/mobile/src/screens/home/GratitudeTimeline.tsx
@@ -21,6 +21,7 @@ interface IGratitudeTimelineProps {
   onEntryPress: (entry: Entry) => void;
   onAddEntry?: (dateMs: number) => void;
   onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  onScrollBeginDrag?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 }
 
 const EMPTY_GROUPS = new Map<number, Entry[]>();
@@ -39,6 +40,7 @@ export const GratitudeTimeline: React.FC<IGratitudeTimelineProps> = ({
   onEntryPress,
   onAddEntry,
   onScroll,
+  onScrollBeginDrag,
 }) => {
   const { t } = useTranslation();
   const today = startOfDay(new Date());
@@ -228,6 +230,7 @@ export const GratitudeTimeline: React.FC<IGratitudeTimelineProps> = ({
         ListFooterComponent={<View className="h-8" />}
         contentContainerClassName="pb-4"
         onScroll={onScroll}
+        onScrollBeginDrag={onScrollBeginDrag}
         scrollEventThrottle={16}
       />
     </View>

--- a/apps/mobile/src/screens/home/index.tsx
+++ b/apps/mobile/src/screens/home/index.tsx
@@ -1,5 +1,5 @@
-import { useState, useCallback, useRef } from 'react';
-import { View, type NativeSyntheticEvent, type NativeScrollEvent } from 'react-native';
+import { useState, useCallback } from 'react';
+import { View } from 'react-native';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { startOfDay } from 'date-fns';
 import { useRouter } from 'expo-router';
@@ -7,6 +7,7 @@ import { type Entry } from '~/types';
 import { getEntriesForDay } from '~/db/queries';
 import { combineDateWithCurrentTime } from '~/lib/utils';
 import { useTranslation } from '~/lib/i18n';
+import { useGratitudeActionDockScrollBehavior } from '~/hooks/useGratitudeActionDockScrollBehavior';
 import { SafeAreaView } from '~/components/ui/safe-area-view';
 import { GratitudeDatepickerModal } from '~/components/GratitudeDatepickerModal';
 import { toast } from '~/components/ui/toast';
@@ -15,9 +16,6 @@ import { SearchResults } from './SearchResults';
 import { GratitudeTimeline } from './GratitudeTimeline';
 import { GratitudeActionDock } from './GratitudeActionDock';
 
-/** Minimum scroll delta (in px) to trigger auto-collapse */
-const SCROLL_COLLAPSE_THRESHOLD = 30;
-
 export default function HomeScreen() {
   const router = useRouter();
   const { t } = useTranslation();
@@ -25,10 +23,12 @@ export default function HomeScreen() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
   const [showDatePicker, setShowDatePicker] = useState(false);
-  const [isActionDockExpanded, setIsActionDockExpanded] = useState(true);
-
-  // Track last scroll offset to detect scroll direction
-  const lastScrollY = useRef(0);
+  const {
+    isExpanded: isActionDockExpanded,
+    onToggle: handleActionDockToggle,
+    onScroll: handleTimelineScroll,
+    onScrollBeginDrag: handleTimelineScrollBeginDrag,
+  } = useGratitudeActionDockScrollBehavior();
 
   const handleGratitudeDatepickerPress = useCallback(
     async (date: Date) => {
@@ -106,26 +106,6 @@ export default function HomeScreen() {
     });
   }, [router]);
 
-  /** Auto-collapse the action dock when the user scrolls down */
-  const handleTimelineScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const currentY = event.nativeEvent.contentOffset.y;
-      const delta = currentY - lastScrollY.current;
-
-      // Scrolling down past threshold → collapse
-      if (delta > SCROLL_COLLAPSE_THRESHOLD && isActionDockExpanded) {
-        setIsActionDockExpanded(false);
-      }
-
-      lastScrollY.current = currentY;
-    },
-    [isActionDockExpanded],
-  );
-
-  const handleActionDockToggle = useCallback(() => {
-    setIsActionDockExpanded((prev) => !prev);
-  }, []);
-
   return (
     <SafeAreaView
       className="flex-1 w-full bg-primary"
@@ -157,6 +137,7 @@ export default function HomeScreen() {
             onEntryPress={handleEntryPress}
             onAddEntry={handleAddEntry}
             onScroll={handleTimelineScroll}
+            onScrollBeginDrag={handleTimelineScrollBeginDrag}
           />
 
           <GratitudeActionDock

--- a/apps/mobile/src/screens/home/index.tsx
+++ b/apps/mobile/src/screens/home/index.tsx
@@ -1,22 +1,22 @@
-import { useState, useCallback } from 'react';
-import { View } from 'react-native';
+import { useState, useCallback, useRef } from 'react';
+import { View, type NativeSyntheticEvent, type NativeScrollEvent } from 'react-native';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { startOfDay } from 'date-fns';
 import { useRouter } from 'expo-router';
-import { Calendar } from 'lucide-react-native';
-import { cn } from 'tailwind-variants';
 import { type Entry } from '~/types';
 import { getEntriesForDay } from '~/db/queries';
 import { combineDateWithCurrentTime } from '~/lib/utils';
 import { useTranslation } from '~/lib/i18n';
-import { Button } from '~/components/ui/button';
 import { SafeAreaView } from '~/components/ui/safe-area-view';
 import { GratitudeDatepickerModal } from '~/components/GratitudeDatepickerModal';
-import { Icon } from '~/components/ui/icon';
 import { toast } from '~/components/ui/toast';
 import { Header } from './Header';
 import { SearchResults } from './SearchResults';
 import { GratitudeTimeline } from './GratitudeTimeline';
+import { GratitudeActionDock } from './GratitudeActionDock';
+
+/** Minimum scroll delta (in px) to trigger auto-collapse */
+const SCROLL_COLLAPSE_THRESHOLD = 30;
 
 export default function HomeScreen() {
   const router = useRouter();
@@ -25,6 +25,10 @@ export default function HomeScreen() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
   const [showDatePicker, setShowDatePicker] = useState(false);
+  const [isActionDockExpanded, setIsActionDockExpanded] = useState(true);
+
+  // Track last scroll offset to detect scroll direction
+  const lastScrollY = useRef(0);
 
   const handleGratitudeDatepickerPress = useCallback(
     async (date: Date) => {
@@ -93,6 +97,35 @@ export default function HomeScreen() {
     [router],
   );
 
+  /** Add a new entry for today */
+  const handleAddTodayEntry = useCallback(() => {
+    const now = new Date();
+    router.push({
+      pathname: '/gratitudeEntry',
+      params: { dateMs: now.getTime().toString() },
+    });
+  }, [router]);
+
+  /** Auto-collapse the action dock when the user scrolls down */
+  const handleTimelineScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const currentY = event.nativeEvent.contentOffset.y;
+      const delta = currentY - lastScrollY.current;
+
+      // Scrolling down past threshold → collapse
+      if (delta > SCROLL_COLLAPSE_THRESHOLD && isActionDockExpanded) {
+        setIsActionDockExpanded(false);
+      }
+
+      lastScrollY.current = currentY;
+    },
+    [isActionDockExpanded],
+  );
+
+  const handleActionDockToggle = useCallback(() => {
+    setIsActionDockExpanded((prev) => !prev);
+  }, []);
+
   return (
     <SafeAreaView
       className="flex-1 w-full bg-primary"
@@ -123,19 +156,15 @@ export default function HomeScreen() {
           <GratitudeTimeline
             onEntryPress={handleEntryPress}
             onAddEntry={handleAddEntry}
+            onScroll={handleTimelineScroll}
           />
-          {/* FAB (Floating Action Button) - positioned independently */}
-          <Button
-            size="icon"
-            variant="primary"
-            onPress={() => setShowDatePicker(true)}
-            className={cn(
-              'absolute bottom-safe-or-20 ios:bottom-safe-or-12 right-safe-or-6 z-10',
-              'h-14 w-14 items-center justify-center rounded-full',
-              'shadow-lg shadow-black/25',
-            )}>
-            <Icon as={Calendar} className="text-primary-foreground" />
-          </Button>
+
+          <GratitudeActionDock
+            isExpanded={isActionDockExpanded}
+            onToggle={handleActionDockToggle}
+            onAddEntry={handleAddTodayEntry}
+            onPickDate={() => setShowDatePicker(true)}
+          />
 
           <GratitudeDatepickerModal
             visible={showDatePicker}

--- a/apps/mobile/src/screens/settings/sections/DangerZoneSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/DangerZoneSection.tsx
@@ -28,9 +28,7 @@ export function DangerZoneSection() {
   const router = useRouter();
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const resetCustomWorksheetTemplate = useSettingsStore(
-    (state) => state.resetCustomWorksheetTemplate,
-  );
+  const resetSettingsToDefaults = useSettingsStore((state) => state.resetToDefaults);
 
   const [showDeleteConfirmDialog, setShowDeleteConfirmDialog] = useState(false);
 
@@ -40,9 +38,9 @@ export function DangerZoneSection() {
       // Wipe the DB first — if this throws, the files are still intact
       // and the catch block will surface the error to the user.
       await deleteAllData();
-      // Clear persisted journaling text alongside the DB wipe so "Delete All
-      // Data" removes user-authored worksheet content too.
-      resetCustomWorksheetTemplate();
+      // Reset persisted app settings alongside the DB wipe so Delete All Data
+      // restores the app to its default state.
+      resetSettingsToDefaults();
       // Invalidate and await refetch of all cached queries so the mounted
       // home screen receives empty data from the cleared DB before we navigate
       // back. Using invalidateQueries (not removeQueries) ensures active
@@ -77,7 +75,7 @@ export function DangerZoneSection() {
       const message = error instanceof Error ? error.message : t('Delete failed');
       toast.error(message);
     }
-  }, [t, router, queryClient, resetCustomWorksheetTemplate]);
+  }, [t, router, queryClient, resetSettingsToDefaults]);
 
   return (
     <>

--- a/apps/mobile/src/screens/settings/sections/DangerZoneSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/DangerZoneSection.tsx
@@ -66,9 +66,13 @@ export function DangerZoneSection() {
         cleanupErrors.push(error instanceof Error ? error.message : String(error));
       }
       if (cleanupErrors.length > 0) {
-        throw new Error(cleanupErrors.join('\n'));
+        toast.warning(t('All data deleted, but some media files could not be removed.'), {
+          description: cleanupErrors.join('\n'),
+          duration: 8000,
+        });
+      } else {
+        toast.success(t('All data deleted'));
       }
-      toast.success(t('All data deleted'));
       // Navigate to home screen
       router.dismissTo('/');
     } catch (error) {

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "expo-document-picker": "~55.0.8",
         "expo-file-system": "~55.0.10",
         "expo-font": "~55.0.4",
+        "expo-haptics": "~55.0.14",
         "expo-image-manipulator": "~55.0.10",
         "expo-image-picker": "~55.0.12",
         "expo-linking": "~55.0.7",
@@ -1477,6 +1478,8 @@
     "expo-font": ["expo-font@55.0.4", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-ZKeGTFffPygvY5dM/9ATM2p7QDkhsaHopH7wFAWgP2lKzqUMS9B/RxCvw5CaObr9Ro7x9YptyeRKX2HmgmMfrg=="],
 
     "expo-glass-effect": ["expo-glass-effect@55.0.8", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-IvUjHb/4t6r2H/LXDjcQ4uDoHrmO2cLOvEb9leLavQ4HX5+P4LRtQrMDMlkWAn5Wo5DkLcG8+1CrQU2nqgogTA=="],
+
+    "expo-haptics": ["expo-haptics@55.0.14", "", { "peerDependencies": { "expo": "*" } }, "sha512-KjDItBsA9mi1f5nRwf8g1wOdfEcLHwvEdt5Jl1sMCDETR/homcGOl+F3QIiPOl/PRlbGVieQsjTtF4DGtHOj6g=="],
 
     "expo-image": ["expo-image@55.0.6", "", { "dependencies": { "sf-symbols-typescript": "^2.2.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-TKuu0uBmgTZlhd91Glv+V4vSBMlfl0bdQxfl97oKKZUo3OBC13l3eLik7v3VNLJN7PZbiwOAiXkZkqSOBx/Xsw=="],
 


### PR DESCRIPTION
- replace static FAB with interactive GratitudeActionDock component
- implement long-press and pan gesture for dock repositioning via useGratitudeActionDockDrag hook
- add auto-collapse functionality on timeline scroll down
- integrate expo-haptics for tactile feedback during interactions
- add translations for new dock actions (Write now, Pick a date, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added expandable Gratitude Action Dock with "Write now" and "Pick a date" buttons, replacing the previous floating action button
  * Dock position is now remembered between app sessions
  * Added haptic feedback support
  * New "Reset to Defaults" option in settings

* **Bug Fixes**
  * Data deletion now gracefully handles media file cleanup failures with informative warnings instead of errors

* **Internationalization**
  * Added new UI string translations across Arabic, English, Hebrew, Simplified Chinese, and Traditional Chinese

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mehradotdev/tackbok/pull/47)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->