### PR TITLE
fix(mobile): use CJS theme registry for Metro and add expo-sharing plugin

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -69,7 +69,8 @@
           ]
         }
       ],
-      "expo-font"
+      "expo-font",
+      "expo-sharing"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -2,7 +2,12 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { getDefaultConfig } from 'expo/metro-config.js';
 import { withUniwindConfig } from 'uniwind/metro';
-import { CUSTOM_THEME_IDS } from './src/lib/theme/registry.js';
+import themeRegistry from './src/lib/theme/registry.cjs';
+
+// Metro config runs under Node. The generated runtime registry stays ESM for app
+// imports, so Metro reads the CommonJS companion and plucks values from the
+// default import instead of relying on named imports from a CJS module.
+const { CUSTOM_THEME_IDS } = themeRegistry;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,13 +16,6 @@ const projectRoot = __dirname;
 
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(projectRoot);
-
-// Bun isolated linker: all deps are symlinks in apps/mobile/node_modules/ pointing
-// into root/node_modules/.bun/ — no hoisted deps at monorepo root to watch/resolve.
-config.resolver.nodeModulesPaths = [path.resolve(projectRoot, 'node_modules')];
-
-// Allow Metro to follow symlinks into the .bun central store
-config.resolver.unstable_enableSymlinks = true;
 
 // Add SQL source extension for Drizzle
 config.resolver.sourceExts.push('sql');

--- a/apps/mobile/src/lib/theme/README.md
+++ b/apps/mobile/src/lib/theme/README.md
@@ -9,9 +9,11 @@ This folder contains the source of truth and generated artifacts for theme and f
   This is the first file to edit when adding or removing a theme or title font.
 - `generate-theme-artifacts.ts`
   Generates the runtime artifacts consumed by Metro, TypeScript, and Uniwind.
-  It updates or creates `src/global.css`, `registry.js`, and `registry.d.ts` from `theme-tokens.ts`.
+  It updates or creates `src/global.css`, `registry.js`, `registry.cjs`, and `registry.d.ts` from `theme-tokens.ts`.
 - `registry.js`
-  Generated metadata artifact used by Metro and runtime imports that need plain JavaScript.
+  Generated ESM metadata artifact used by runtime imports that need plain JavaScript.
+- `registry.cjs`
+  Generated CommonJS metadata artifact used by Node-side tooling such as Metro config.
 - `registry.d.ts`
   Generated TypeScript contract for the generated registry artifact.
 - `themes.ts`
@@ -94,6 +96,7 @@ That means:
 ## Generated Files
 
 - `registry.js`
+- `registry.cjs`
 - `registry.d.ts`
 - The generated theme sections inside `src/global.css`
 
@@ -106,7 +109,7 @@ Do not edit those by hand. Edit `theme-tokens.ts` and regenerate them instead.
 The generator keeps the runtime theming model simple:
 
 1. `theme-tokens.ts` defines theme metadata and token values.
-2. `generate-theme-artifacts.ts` generates `registry.js`, `registry.d.ts`, and the theme sections in `src/global.css`.
+2. `generate-theme-artifacts.ts` generates `registry.js`, `registry.cjs`, `registry.d.ts`, and the theme sections in `src/global.css`.
 3. Metro + Uniwind regenerate `src/uniwind-types.d.ts` from the configured theme list.
 4. Uniwind still reads the generated CSS and runtime switching still uses `Uniwind.setTheme()`.
 

--- a/apps/mobile/src/lib/theme/generate-theme-artifacts.ts
+++ b/apps/mobile/src/lib/theme/generate-theme-artifacts.ts
@@ -23,8 +23,9 @@ import {
  *   rewrites the generated theme token section below it. If the file is missing,
  *   empty, or imports-only, the script bootstraps it with the required imports and
  *   a minimal handwritten shell before appending generated content.
- * - registry.js: generated JavaScript registry used by runtime code and Metro config.
- * - registry.d.ts: generated TypeScript declarations for the JS registry.
+ * - registry.js: generated ESM registry used by runtime code.
+ * - registry.cjs: generated CommonJS registry used by Node-side tooling.
+ * - registry.d.ts: generated TypeScript declarations for the ESM registry.
  *
  * Re-running the script is safe and idempotent: manual CSS stays user-owned, while
  * the generated theme block and registry artifacts are replaced from the canonical
@@ -39,6 +40,7 @@ const themeDir = __dirname;
 const appRoot = path.resolve(themeDir, '../..');
 const globalCssPath = path.resolve(appRoot, 'global.css');
 const registryJsPath = path.resolve(themeDir, 'registry.js');
+const registryCjsPath = path.resolve(themeDir, 'registry.cjs');
 const registryDtsPath = path.resolve(themeDir, 'registry.d.ts');
 const GLOBAL_CSS_IMPORTS = `@import 'tailwindcss';\n@import 'uniwind';`;
 
@@ -197,10 +199,14 @@ function appendGeneratedThemeArtifactsSection(content: string): string {
   return `${manualContent}\n\n${buildGeneratedThemeArtifactsSection()}\n`;
 }
 
-function generateRegistryJs(): string {
-  const themes = THEME_DEFINITIONS.map(
+function getRegistryThemes() {
+  return THEME_DEFINITIONS.map(
     ({ tokens: _tokens, bodyFontPackId: _bodyFontPackId, ...theme }) => theme,
   );
+}
+
+function generateRegistryJs(): string {
+  const themes = getRegistryThemes();
 
   return [
     `// This file is generated from ${THEME_TOKENS_SOURCE}. Do not edit by hand.`,
@@ -216,6 +222,36 @@ function generateRegistryJs(): string {
     'export const CUSTOM_THEME_IDS = THEMES.filter(',
     `  (theme) => theme.id !== ${toJsLiteral(DEFAULT_THEME_ID)} && theme.id !== 'dark',`,
     ').map((theme) => theme.id);',
+    '',
+  ].join('\n');
+}
+
+function generateRegistryCjs(): string {
+  const themes = getRegistryThemes();
+
+  return [
+    `// This file is generated from ${THEME_TOKENS_SOURCE}. Do not edit by hand.`,
+    '',
+    `const TITLE_FONTS = ${toJsLiteral(TITLE_FONTS)};`,
+    '',
+    `const DEFAULT_THEME_ID = ${toJsLiteral(DEFAULT_THEME_ID)};`,
+    `const DEFAULT_TITLE_FONT = ${toJsLiteral(DEFAULT_TITLE_FONT)};`,
+    '',
+    `const THEMES = ${toJsLiteral(themes)};`,
+    '',
+    'const THEME_IDS = THEMES.map((theme) => theme.id);',
+    'const CUSTOM_THEME_IDS = THEMES.filter(',
+    `  (theme) => theme.id !== ${toJsLiteral(DEFAULT_THEME_ID)} && theme.id !== 'dark',`,
+    ').map((theme) => theme.id);',
+    '',
+    'module.exports = {',
+    '  TITLE_FONTS,',
+    '  DEFAULT_THEME_ID,',
+    '  DEFAULT_TITLE_FONT,',
+    '  THEMES,',
+    '  THEME_IDS,',
+    '  CUSTOM_THEME_IDS,',
+    '};',
     '',
   ].join('\n');
 }
@@ -287,6 +323,7 @@ function main() {
 
   writeIfChanged(globalCssPath, nextGlobalCss);
   writeIfChanged(registryJsPath, generateRegistryJs());
+  writeIfChanged(registryCjsPath, generateRegistryCjs());
   writeIfChanged(registryDtsPath, generateRegistryDts());
 
   console.log('Generated theme artifacts from theme-tokens.ts');

--- a/apps/mobile/src/lib/theme/metro-config.test.ts
+++ b/apps/mobile/src/lib/theme/metro-config.test.ts
@@ -6,11 +6,12 @@ const METRO_CONFIG_PATH = path.resolve(__dirname, '../../../metro.config.js');
 describe('Metro Theme Config', () => {
   const metroConfigSource = fs.readFileSync(METRO_CONFIG_PATH, 'utf-8');
 
-  test('imports CUSTOM_THEME_IDS from the shared registry', () => {
-    // Keep the explicit .js extension here: metro.config.js is ESM and imports
-    // the generated runtime registry artifact directly.
+  test('imports the CommonJS theme registry for Node-side tooling', () => {
     expect(metroConfigSource).toMatch(
-      /import\s*\{\s*CUSTOM_THEME_IDS\s*\}\s*from\s*['"]\.\/src\/lib\/theme\/registry\.js['"]\s*;?/,
+      /import\s+themeRegistry\s+from\s+['"]\.\/src\/lib\/theme\/registry\.cjs['"]\s*;?/,
+    );
+    expect(metroConfigSource).toMatch(
+      /const\s*\{\s*CUSTOM_THEME_IDS\s*\}\s*=\s*themeRegistry\s*;?/,
     );
   });
 

--- a/apps/mobile/src/lib/theme/registry.cjs
+++ b/apps/mobile/src/lib/theme/registry.cjs
@@ -1,0 +1,153 @@
+// This file is generated from src/lib/theme/theme-tokens.ts. Do not edit by hand.
+
+const TITLE_FONTS = [
+  {
+    "id": "figtree",
+    "label": "Figtree",
+    "fontFamily": "Figtree_700Bold"
+  },
+  {
+    "id": "lora",
+    "label": "Lora",
+    "fontFamily": "Lora_700Bold"
+  },
+  {
+    "id": "gloriahallelujah",
+    "label": "Gloria Hallelujah",
+    "fontFamily": "GloriaHallelujah_400Regular"
+  },
+  {
+    "id": "cinzel",
+    "label": "Cinzel",
+    "fontFamily": "Cinzel_700Bold"
+  },
+  {
+    "id": "spacemono",
+    "label": "Space Mono",
+    "fontFamily": "SpaceMono_700Bold"
+  }
+];
+
+const DEFAULT_THEME_ID = "light";
+const DEFAULT_TITLE_FONT = "figtree";
+
+const THEMES = [
+  {
+    "id": "light",
+    "name": "Light",
+    "description": "Warm beige/olive (DEFAULT)",
+    "variant": "light",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "figtree"
+  },
+  {
+    "id": "dark",
+    "name": "Dark",
+    "description": "Earthy dark (DEFAULT DARK)",
+    "variant": "dark",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "figtree"
+  },
+  {
+    "id": "lavender",
+    "name": "Lavender",
+    "description": "Gentle purple/lavender",
+    "variant": "light",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "lora"
+  },
+  {
+    "id": "forest",
+    "name": "Forest",
+    "description": "Deep green/moss",
+    "variant": "dark",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "gloriahallelujah"
+  },
+  {
+    "id": "bubblegum",
+    "name": "Bubblegum",
+    "description": "Neo-Brutalism Pop",
+    "variant": "light",
+    "enableTimelineBorders": true,
+    "defaultTitleFontId": "spacemono"
+  },
+  {
+    "id": "hecker",
+    "name": "Hecker",
+    "description": "Cyberpunk/Retro-Futurism",
+    "variant": "dark",
+    "enableTimelineBorders": true,
+    "defaultTitleFontId": "spacemono"
+  },
+  {
+    "id": "peach",
+    "name": "Peach",
+    "description": "Warm peach/coral pastels",
+    "variant": "light",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "lora"
+  },
+  {
+    "id": "ember",
+    "name": "Ember",
+    "description": "Warm charcoal/amber",
+    "variant": "dark",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "cinzel"
+  },
+  {
+    "id": "ocean",
+    "name": "Ocean",
+    "description": "Coastal blues and sand",
+    "variant": "light",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "cinzel"
+  },
+  {
+    "id": "navy",
+    "name": "Navy",
+    "description": "Deep navy/slate blue",
+    "variant": "dark",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "cinzel"
+  },
+  {
+    "id": "sakura",
+    "name": "Sakura",
+    "description": "Soft pink/cherry blossom",
+    "variant": "light",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "figtree"
+  },
+  {
+    "id": "slate",
+    "name": "Slate",
+    "description": "Neutral dark monochrome",
+    "variant": "dark",
+    "enableTimelineBorders": false,
+    "defaultTitleFontId": "gloriahallelujah"
+  },
+  {
+    "id": "kela",
+    "name": "Kela",
+    "description": "Neo-Brutalism",
+    "variant": "light",
+    "enableTimelineBorders": true,
+    "defaultTitleFontId": "spacemono"
+  }
+];
+
+const THEME_IDS = THEMES.map((theme) => theme.id);
+const CUSTOM_THEME_IDS = THEMES.filter(
+  (theme) => theme.id !== "light" && theme.id !== 'dark',
+).map((theme) => theme.id);
+
+module.exports = {
+  TITLE_FONTS,
+  DEFAULT_THEME_ID,
+  DEFAULT_TITLE_FONT,
+  THEMES,
+  THEME_IDS,
+  CUSTOM_THEME_IDS,
+};

--- a/apps/mobile/src/lib/theme/theme-registry.test.ts
+++ b/apps/mobile/src/lib/theme/theme-registry.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import { createRequire } from 'module';
 import * as path from 'path';
 import {
   CUSTOM_THEME_IDS,
@@ -18,7 +19,9 @@ import {
 
 const GLOBAL_CSS_PATH = path.resolve(__dirname, '../../global.css');
 const FONTS_MODULE_PATH = path.resolve(__dirname, './fonts.ts');
+const REGISTRY_CJS_PATH = path.resolve(__dirname, './registry.cjs');
 const UNIWIND_TYPES_PATH = path.resolve(__dirname, '../../uniwind-types.d.ts');
+const loadCommonJsModule = createRequire(__filename);
 
 function extractVariantBlock(content: string, variantId: string): string {
   const variantMarker = `@variant ${variantId}`;
@@ -99,6 +102,7 @@ function extractUniwindThemeIds(content: string): string[] {
 describe('Theme Registry', () => {
   const globalCss = fs.readFileSync(GLOBAL_CSS_PATH, 'utf-8');
   const fontsModule = fs.readFileSync(FONTS_MODULE_PATH, 'utf-8');
+  const commonJsRegistry = loadCommonJsModule(REGISTRY_CJS_PATH) as typeof import('./registry');
   const uniwindTypesModule = fs.readFileSync(UNIWIND_TYPES_PATH, 'utf-8');
   const titleFontsById = new Map(TITLE_FONTS.map((font) => [font.id, font]));
   const loadedFontFamilies = new Set(extractAppFontAssetNames(fontsModule));
@@ -130,6 +134,15 @@ describe('Theme Registry', () => {
     expect(DEFAULT_TITLE_FONT).toBe(SOURCE_DEFAULT_TITLE_FONT);
     expect(TITLE_FONTS).toEqual(SOURCE_TITLE_FONTS);
     expect(THEMES).toEqual(sourceThemes);
+  });
+
+  test('generated CommonJS registry stays in sync with the ESM registry', () => {
+    expect(commonJsRegistry.DEFAULT_THEME_ID).toBe(DEFAULT_THEME_ID);
+    expect(commonJsRegistry.DEFAULT_TITLE_FONT).toBe(DEFAULT_TITLE_FONT);
+    expect(commonJsRegistry.TITLE_FONTS).toEqual(TITLE_FONTS);
+    expect(commonJsRegistry.THEMES).toEqual(THEMES);
+    expect(commonJsRegistry.THEME_IDS).toEqual(THEMES.map((theme) => theme.id));
+    expect(commonJsRegistry.CUSTOM_THEME_IDS).toEqual(CUSTOM_THEME_IDS);
   });
 
   test('default ids exist in the shared registries', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expo-sharing plugin support to the mobile app.

* **Chores**
  * Updated theme registry implementation to support CommonJS format alongside ESM.
  * Enhanced theme registry test coverage to verify synchronization between registry formats.
  * Removed legacy build configuration for improved system compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mehradotdev/tackbok/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->