### PR TITLE
fix(mobile): harden native audio encoder against silent failures

### DIFF
--- a/apps/mobile/src/inlineModules/AudioEncoderModule.kt
+++ b/apps/mobile/src/inlineModules/AudioEncoderModule.kt
@@ -19,6 +19,12 @@ private const val CODEC_TIMEOUT_US = 10_000L
 private const val ERROR_ENCODE = "E_AUDIO_ENCODE"
 
 /**
+ * Abort if the codec makes no forward progress for this long. Measured against
+ * progress rather than total runtime so long recordings aren't cut short.
+ */
+private const val CODEC_STALL_TIMEOUT_MS = 15_000L
+
+/**
  * Inline native module that encodes a WAV file to M4A (AAC) using Android's
  * MediaCodec + MediaMuxer with no extra native dependencies.
  */
@@ -36,6 +42,15 @@ class AudioEncoderModule : Module() {
         )
 
         encodeWavToM4a(wavFile, outputFile, actualBitrate)
+
+        // Guard against resolving with a file the muxer never actually wrote.
+        // Callers delete the source WAV once we report success, so handing back
+        // an empty file would lose the recording outright.
+        if (!outputFile.exists() || outputFile.length() == 0L) {
+          outputFile.delete()
+          throw IOException("Encoder produced an empty M4A file")
+        }
+
         promise.resolve(Uri.fromFile(outputFile).toString())
       } catch (e: Exception) {
         promise.reject(ERROR_ENCODE, e.message ?: "Audio encoding failed", e)
@@ -48,6 +63,28 @@ class AudioEncoderModule : Module() {
       File(Uri.parse(uriString).path ?: throw IOException("Invalid file URI"))
     } else {
       File(uriString)
+    }
+  }
+
+  /**
+   * [FileInputStream.skip] may skip fewer bytes than requested. Under-skipping
+   * would feed WAV header bytes to the encoder as if they were audio, producing
+   * an audible click with no error, so keep going until the full count is done.
+   */
+  private fun skipFully(stream: FileInputStream, count: Long) {
+    var remaining = count
+    while (remaining > 0) {
+      val skipped = stream.skip(remaining)
+      if (skipped > 0) {
+        remaining -= skipped
+      } else {
+        // skip() is allowed to return 0; fall back to a byte read so we either
+        // make progress or discover we've hit EOF.
+        if (stream.read() < 0) {
+          throw IOException("Unexpected end of file while skipping WAV header")
+        }
+        remaining -= 1
+      }
     }
   }
 
@@ -123,7 +160,7 @@ class AudioEncoderModule : Module() {
       encoderStarted = true
 
       FileInputStream(wavFile).use { fis ->
-        fis.skip(wav.dataOffset.toLong())
+        skipFully(fis, wav.dataOffset.toLong())
 
         val bufferInfo = MediaCodec.BufferInfo()
         var totalBytesRead = 0
@@ -131,11 +168,17 @@ class AudioEncoderModule : Module() {
         val bytesPerFrame = bytesPerSample * wav.channels
         var presentationTimeUs = 0L
         var inputDone = false
+        var lastProgressMs = System.currentTimeMillis()
 
         while (true) {
+          if (System.currentTimeMillis() - lastProgressMs > CODEC_STALL_TIMEOUT_MS) {
+            throw IOException("Encoder stalled with no output; aborting")
+          }
+
           if (!inputDone) {
             val inputIndex = encoder.dequeueInputBuffer(CODEC_TIMEOUT_US)
             if (inputIndex >= 0) {
+              lastProgressMs = System.currentTimeMillis()
               val inputBuffer = encoder.getInputBuffer(inputIndex)!!
               inputBuffer.clear()
 
@@ -174,6 +217,9 @@ class AudioEncoderModule : Module() {
           }
 
           val outputIndex = encoder.dequeueOutputBuffer(bufferInfo, CODEC_TIMEOUT_US)
+          if (outputIndex >= 0 || outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+            lastProgressMs = System.currentTimeMillis()
+          }
           when {
             outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
               if (!muxerStarted) {
@@ -204,6 +250,13 @@ class AudioEncoderModule : Module() {
               }
             }
           }
+        }
+
+        // If the output format never arrived, the muxer was never started and
+        // every sample above was silently discarded. Reaching end-of-stream is
+        // not by itself proof that anything was written.
+        if (!muxerStarted) {
+          throw IOException("Encoder never produced an output format; no audio was written")
         }
       }
     } catch (error: Exception) {

--- a/apps/mobile/src/inlineModules/AudioEncoderModule.kt
+++ b/apps/mobile/src/inlineModules/AudioEncoderModule.kt
@@ -5,6 +5,7 @@ import android.media.MediaCodecInfo
 import android.media.MediaFormat
 import android.media.MediaMuxer
 import android.net.Uri
+import android.os.SystemClock
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -168,17 +169,20 @@ class AudioEncoderModule : Module() {
         val bytesPerFrame = bytesPerSample * wav.channels
         var presentationTimeUs = 0L
         var inputDone = false
-        var lastProgressMs = System.currentTimeMillis()
+        // Monotonic, and excludes deep sleep — during which the codec could not
+        // have progressed anyway. System.currentTimeMillis() is wall-clock and
+        // can jump backwards (NTP, DST), which would disable this guard.
+        var lastProgressMs = SystemClock.uptimeMillis()
 
         while (true) {
-          if (System.currentTimeMillis() - lastProgressMs > CODEC_STALL_TIMEOUT_MS) {
+          if (SystemClock.uptimeMillis() - lastProgressMs > CODEC_STALL_TIMEOUT_MS) {
             throw IOException("Encoder stalled with no output; aborting")
           }
 
           if (!inputDone) {
             val inputIndex = encoder.dequeueInputBuffer(CODEC_TIMEOUT_US)
             if (inputIndex >= 0) {
-              lastProgressMs = System.currentTimeMillis()
+              lastProgressMs = SystemClock.uptimeMillis()
               val inputBuffer = encoder.getInputBuffer(inputIndex)!!
               inputBuffer.clear()
 
@@ -218,7 +222,7 @@ class AudioEncoderModule : Module() {
 
           val outputIndex = encoder.dequeueOutputBuffer(bufferInfo, CODEC_TIMEOUT_US)
           if (outputIndex >= 0 || outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
-            lastProgressMs = System.currentTimeMillis()
+            lastProgressMs = SystemClock.uptimeMillis()
           }
           when {
             outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {

--- a/apps/mobile/src/inlineModules/AudioEncoderModule.swift
+++ b/apps/mobile/src/inlineModules/AudioEncoderModule.swift
@@ -1,4 +1,4 @@
-import ExpoModulesCore
+internal import ExpoModulesCore
 import AVFoundation
 
 private let defaultBitrate = 64000
@@ -6,8 +6,8 @@ private let errorEncode = "E_AUDIO_ENCODE"
 
 /// Inline native module that encodes a WAV file to M4A (AAC) using
 /// AVAssetReader + AVAssetWriter — zero extra dependencies, hardware-accelerated.
-public class AudioEncoderModule: Module {
-  public func definition() -> ModuleDefinition {
+class AudioEncoderModule: Module {
+  func definition() -> ModuleDefinition {
     Name("AudioEncoderModule")
 
     AsyncFunction("encodeWavToM4a") { (wavUriString: String, bitrate: Int?) -> String in
@@ -84,42 +84,82 @@ public class AudioEncoderModule: Module {
     writerInput.expectsMediaDataInRealTime = false
     writer.add(writerInput)
 
-    // Start reading and writing
-    reader.startReading()
-    writer.startWriting()
+    // Start reading and writing. Both return false on failure — check before
+    // going further: calling startSession on a writer that isn't in .writing
+    // raises an ObjC exception, which Swift cannot catch (it would terminate
+    // the app rather than reject the promise).
+    guard reader.startReading() else {
+      throw Exception(
+        name: errorEncode,
+        description: reader.error?.localizedDescription ?? "Could not start reading WAV file"
+      )
+    }
+    guard writer.startWriting() else {
+      reader.cancelReading()
+      throw Exception(
+        name: errorEncode,
+        description: writer.error?.localizedDescription ?? "Could not start writing M4A file"
+      )
+    }
     writer.startSession(atSourceTime: .zero)
 
     // Process samples on a background queue
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
       let queue = DispatchQueue(label: "dev.mehra.tackbok.audio-encoder")
+
+      // AVFoundation may invoke the callback again after we've settled (and
+      // finishWriting's completion can race with it). Resuming a continuation
+      // twice is a fatal error, so funnel every exit through this guard.
+      let settled = NSLock()
+      var hasResumed = false
+      func finish(_ result: Result<Void, Error>) {
+        settled.lock()
+        defer { settled.unlock() }
+        guard !hasResumed else { return }
+        hasResumed = true
+        continuation.resume(with: result)
+      }
+
+      func fail(_ description: String) {
+        finish(.failure(Exception(name: errorEncode, description: description)))
+      }
+
       writerInput.requestMediaDataWhenReady(on: queue) {
         while writerInput.isReadyForMoreMediaData {
-          if let sampleBuffer = readerOutput.copyNextSampleBuffer() {
-            writerInput.append(sampleBuffer)
-          } else {
+          // Sample buffers are autoreleased; without a pool they accumulate
+          // for the whole drain loop instead of the current iteration.
+          let shouldContinue = autoreleasepool { () -> Bool in
+            if let sampleBuffer = readerOutput.copyNextSampleBuffer() {
+              guard writerInput.append(sampleBuffer) else {
+                // Writer rejected the sample — stop now and report the real
+                // cause rather than spinning until the reader drains.
+                writer.cancelWriting()
+                reader.cancelReading()
+                fail(writer.error?.localizedDescription ?? "Writer rejected sample data")
+                return false
+              }
+              return true
+            }
+
             writerInput.markAsFinished()
 
             if reader.status == .failed {
               writer.cancelWriting()
-              continuation.resume(throwing: Exception(
-                name: errorEncode,
-                description: reader.error?.localizedDescription ?? "Reader failed"
-              ))
-              return
+              fail(reader.error?.localizedDescription ?? "Reader failed")
+              return false
             }
 
             writer.finishWriting {
               if writer.status == .failed {
-                continuation.resume(throwing: Exception(
-                  name: errorEncode,
-                  description: writer.error?.localizedDescription ?? "Writer failed"
-                ))
+                fail(writer.error?.localizedDescription ?? "Writer failed")
               } else {
-                continuation.resume()
+                finish(.success(()))
               }
             }
-            return
+            return false
           }
+
+          if !shouldContinue { return }
         }
       }
     }


### PR DESCRIPTION
The iOS encoder discarded the Bool returned by startWriting(), so a failed writer would reach startSession() and raise an ObjC exception — terminating the app instead of rejecting the promise the JS fallback catches. It also resumed its continuation from a callback AVFoundation may invoke more than once, and drained sample buffers without an autoreleasepool.

The Android encoder gated writeSampleData() on muxerStarted but never verified it, so if the output format never arrived every sample was silently dropped and the promise still resolved. Callers delete the source WAV on success, so that path destroyed the recording. Its encode loop also had no exit other than end-of-stream, and skip() was assumed to skip fully.

- ios: check startReading/startWriting before startSession
- ios: funnel continuation exits through a lock-guarded resume-once
- ios: wrap the drain loop in autoreleasepool; check append()
- android: throw when the muxer never started or the output is empty
- android: abort after 15s without codec progress
- android: skip the WAV header fully instead of trusting skip()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio encoding reliability by detecting stalled encoding processes and failing promptly.
  * Added validation to prevent empty or incomplete M4A files from being produced.
  * Improved WAV data handling and error reporting for invalid or unreadable input.
  * Prevented encoding crashes caused by race conditions during asynchronous processing.
  * Ensured encoding failures are reported and handled cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->