### PR TITLE
feat(mobile): implement daily reminder notifications via expo-notifications

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -16,6 +16,8 @@ import { useMigrations } from 'drizzle-orm/expo-sqlite/migrator';
 import { db } from '~/db';
 import migrations from '~/drizzle/migrations';
 import { useSettingsStore } from '~/lib/settings';
+import { useLocaleStore } from '~/lib/i18n';
+import { initReminders, useReminderTapObserver } from '~/lib/reminders';
 import { cleanupDeferredBackupZipFiles } from '~/lib/backupExport';
 import { getThemeConfig, DEFAULT_THEME_ID } from '~/lib/theme/themes';
 import { AppLoadingScreen } from '~/components/AppLoadingScreen';
@@ -49,10 +51,18 @@ const queryClient = new QueryClient({
   },
 });
 
+// Rendered inside the navigator so reminder-tap navigation happens against a
+// mounted router (covers both cold-start and warm notification taps).
+function ReminderNavigationObserver() {
+  useReminderTapObserver();
+  return null;
+}
+
 export default function Layout() {
   const { success, error } = useMigrations(db, migrations);
   const theme = useSettingsStore((s) => s.theme);
   const hasHydrated = useSettingsStore((s) => s._hasHydrated);
+  const localeHasHydrated = useLocaleStore((s) => s._hasHydrated);
   const themeConfig = getThemeConfig(theme);
 
   const [fontsLoaded, fontsError] = useFonts(APP_FONT_ASSETS);
@@ -85,6 +95,14 @@ export default function Layout() {
       cleanupDeferredBackupZipFiles(0);
     }
   }, [hasHydrated]);
+
+  // Reminder resync needs persisted settings (enabled/time) and the locale
+  // (notification text is baked at schedule time) before it can run.
+  useEffect(() => {
+    if (hasHydrated && localeHasHydrated) {
+      initReminders();
+    }
+  }, [hasHydrated, localeHasHydrated]);
 
   // Show migration error
   if (error) {
@@ -152,6 +170,7 @@ export default function Layout() {
                 }}
               />
             </Stack>
+            <ReminderNavigationObserver />
             <StatusBar style={themeConfig.variant === 'dark' ? 'light' : 'dark'} />
             <Toaster />
             <PortalHost />

--- a/apps/mobile/src/app/gratitudeEntry/index.tsx
+++ b/apps/mobile/src/app/gratitudeEntry/index.tsx
@@ -2,8 +2,9 @@ import { useLocalSearchParams } from 'expo-router';
 import GratitudeEntryScreen from '~/screens/gratitudeEntry';
 
 export default function NewGratitudeEntry() {
-  const { dateMs } = useLocalSearchParams<{
+  const { dateMs, promptTitle } = useLocalSearchParams<{
     dateMs?: string;
+    promptTitle?: string;
   }>();
 
   // Parse dateMs, returning undefined for missing or invalid values (NaN).
@@ -11,5 +12,10 @@ export default function NewGratitudeEntry() {
   const parsed = dateMs ? parseInt(dateMs, 10) : NaN;
   const initialDateMs = isNaN(parsed) ? undefined : parsed;
 
-  return <GratitudeEntryScreen initialDateMs={initialDateMs} />;
+  return (
+    <GratitudeEntryScreen
+      initialDateMs={initialDateMs}
+      initialPromptTitle={typeof promptTitle === 'string' ? promptTitle : undefined}
+    />
+  );
 }

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -7,7 +7,32 @@ import * as schema from './schema';
 // ============================================================================
 
 const DATABASE_NAME = 'tackbok.db';
+// Database file used by expo-sqlite/kv-store, which backs zustand persist.
+const KV_STORE_DATABASE_NAME = 'ExpoSQLiteStorage';
+
 const expo = SQLite.openDatabaseSync(DATABASE_NAME);
+
+// busy_timeout makes SQLite retry for a bit instead of failing immediately
+// with "Error code 5: database is locked", and WAL lets readers and a writer
+// coexist across connections. Both matter in dev on iOS: a JS reload can
+// briefly leave the torn-down runtime's native connection alive (sometimes
+// mid-transaction) alongside the new one, which made startup reads/writes
+// throw uncaught "database is locked" errors.
+expo.execSync('PRAGMA busy_timeout = 2000');
+expo.execSync('PRAGMA journal_mode = WAL');
+
+// Same hardening for the kv-store database. Opening with default options
+// returns the same pooled native connection kv-store itself uses, so the
+// per-connection busy_timeout applies to its reads/writes too (journal_mode
+// is persisted in the file either way). Best effort: a failed attempt is
+// retried on next launch.
+void SQLite.openDatabaseAsync(KV_STORE_DATABASE_NAME)
+  .then((kvDb) =>
+    kvDb.execAsync('PRAGMA busy_timeout = 2000; PRAGMA journal_mode = WAL;'),
+  )
+  .catch((error) => {
+    console.warn('Failed to configure kv-store database:', error);
+  });
 
 export const db = drizzle(expo, { schema });
 

--- a/apps/mobile/src/lib/backupImport/import/presently.test.ts
+++ b/apps/mobile/src/lib/backupImport/import/presently.test.ts
@@ -109,7 +109,7 @@ describe('importFromPresentlyCSV', () => {
     await expect(pickPresentlyImportFile()).resolves.toBeNull();
 
     expect(mockGetDocumentAsync).toHaveBeenCalledWith({
-      type: ['text/csv', 'text/comma-separated-values', 'application/csv', '*/*'],
+      type: ['text/csv', 'text/comma-separated-values', 'application/csv'],
       copyToCacheDirectory: true,
     });
   });

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -253,6 +253,7 @@ export const ar: Translations = {
   'Daily reminder notifications are off': 'إشعارات التذكير اليومية معطلة',
   'Adjust Reminder Time': 'ضبط وقت التذكير',
   'Change your daily reminder time': 'غيّر وقت التذكير اليومي',
+  'Failed to update reminder': 'فشل تحديث التذكير',
   'Notification permission needed': 'مطلوب إذن الإشعارات',
   'To get daily reminders, allow notifications for Tackbok in your device settings.':
     'للحصول على تذكيرات يومية، اسمح بالإشعارات لتطبيق Tackbok من إعدادات جهازك.',

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -253,6 +253,9 @@ export const ar: Translations = {
   'Daily reminder notifications are off': 'إشعارات التذكير اليومية معطلة',
   'Adjust Reminder Time': 'ضبط وقت التذكير',
   'Change your daily reminder time': 'غيّر وقت التذكير اليومي',
+  'Notification permission needed': 'مطلوب إذن الإشعارات',
+  'To get daily reminders, allow notifications for Tackbok in your device settings.':
+    'للحصول على تذكيرات يومية، اسمح بالإشعارات لتطبيق Tackbok من إعدادات جهازك.',
 
   // Settings - Appearance
   Appearance: 'المظهر',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -266,6 +266,7 @@ export const en = {
   'Daily reminder notifications are off': 'Daily reminder notifications are off',
   'Adjust Reminder Time': 'Adjust Reminder Time',
   'Change your daily reminder time': 'Change your daily reminder time',
+  'Failed to update reminder': 'Failed to update reminder',
   'Notification permission needed': 'Notification permission needed',
   'To get daily reminders, allow notifications for Tackbok in your device settings.':
     'To get daily reminders, allow notifications for Tackbok in your device settings.',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -266,6 +266,9 @@ export const en = {
   'Daily reminder notifications are off': 'Daily reminder notifications are off',
   'Adjust Reminder Time': 'Adjust Reminder Time',
   'Change your daily reminder time': 'Change your daily reminder time',
+  'Notification permission needed': 'Notification permission needed',
+  'To get daily reminders, allow notifications for Tackbok in your device settings.':
+    'To get daily reminders, allow notifications for Tackbok in your device settings.',
 
   // Settings - Appearance
   Appearance: 'Appearance',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -254,6 +254,9 @@ export const he: Translations = {
   'Daily reminder notifications are off': 'התראות תזכורת יומיות כבויות',
   'Adjust Reminder Time': 'התאמת זמן התזכורת',
   'Change your daily reminder time': 'שנה את זמן התזכורת היומית שלך',
+  'Notification permission needed': 'נדרשת הרשאת התראות',
+  'To get daily reminders, allow notifications for Tackbok in your device settings.':
+    'כדי לקבל תזכורות יומיות, אפשר התראות עבור Tackbok בהגדרות המכשיר.',
 
   // Settings - Appearance
   Appearance: 'מראה',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -254,6 +254,7 @@ export const he: Translations = {
   'Daily reminder notifications are off': 'התראות תזכורת יומיות כבויות',
   'Adjust Reminder Time': 'התאמת זמן התזכורת',
   'Change your daily reminder time': 'שנה את זמן התזכורת היומית שלך',
+  'Failed to update reminder': 'עדכון התזכורת נכשל',
   'Notification permission needed': 'נדרשת הרשאת התראות',
   'To get daily reminders, allow notifications for Tackbok in your device settings.':
     'כדי לקבל תזכורות יומיות, אפשר התראות עבור Tackbok בהגדרות המכשיר.',

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -249,6 +249,7 @@ export const zhCN: Translations = {
   'Daily reminder notifications are off': '每日提醒通知已关闭',
   'Adjust Reminder Time': '调整提醒时间',
   'Change your daily reminder time': '更改您的每日提醒时间',
+  'Failed to update reminder': '更新提醒失败',
   'Notification permission needed': '需要通知权限',
   'To get daily reminders, allow notifications for Tackbok in your device settings.':
     '要接收每日提醒，请在设备设置中允许 Tackbok 发送通知。',

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -249,6 +249,9 @@ export const zhCN: Translations = {
   'Daily reminder notifications are off': '每日提醒通知已关闭',
   'Adjust Reminder Time': '调整提醒时间',
   'Change your daily reminder time': '更改您的每日提醒时间',
+  'Notification permission needed': '需要通知权限',
+  'To get daily reminders, allow notifications for Tackbok in your device settings.':
+    '要接收每日提醒，请在设备设置中允许 Tackbok 发送通知。',
 
   // Settings - Appearance
   Appearance: '外观',

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -250,6 +250,9 @@ export const zhTW: Translations = {
   'Daily reminder notifications are off': '每日提醒通知已關閉',
   'Adjust Reminder Time': '調整提醒時間',
   'Change your daily reminder time': '變更您的每日提醒時間',
+  'Notification permission needed': '需要通知權限',
+  'To get daily reminders, allow notifications for Tackbok in your device settings.':
+    '要接收每日提醒，請在裝置設定中允許 Tackbok 傳送通知。',
 
   // Settings - Appearance
   Appearance: '外觀',

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -250,6 +250,7 @@ export const zhTW: Translations = {
   'Daily reminder notifications are off': '每日提醒通知已關閉',
   'Adjust Reminder Time': '調整提醒時間',
   'Change your daily reminder time': '變更您的每日提醒時間',
+  'Failed to update reminder': '無法更新提醒',
   'Notification permission needed': '需要通知權限',
   'To get daily reminders, allow notifications for Tackbok in your device settings.':
     '要接收每日提醒，請在裝置設定中允許 Tackbok 傳送通知。',

--- a/apps/mobile/src/lib/reminders.ts
+++ b/apps/mobile/src/lib/reminders.ts
@@ -137,23 +137,30 @@ export async function cancelDailyReminder(): Promise<void> {
  * Makes the OS schedule match the persisted settings. Heals OS reboots,
  * reinstall-with-restored-settings, missed reschedules, and permission
  * revoked behind our back (in which case the toggle flips off).
+ *
+ * Best-effort background healing: never throws (callers fire-and-forget),
+ * and a failed resync leaves settings untouched so the next launch retries.
  */
 export async function resyncReminder(): Promise<void> {
-  const { dailyReminderEnabled, reminderTime, setDailyReminderEnabled } =
-    useSettingsStore.getState();
+  try {
+    const { dailyReminderEnabled, reminderTime, setDailyReminderEnabled } =
+      useSettingsStore.getState();
 
-  if (!dailyReminderEnabled) {
-    await cancelDailyReminder();
-    return;
+    if (!dailyReminderEnabled) {
+      await cancelDailyReminder();
+      return;
+    }
+
+    if (!(await hasReminderPermission())) {
+      setDailyReminderEnabled(false);
+      await cancelDailyReminder();
+      return;
+    }
+
+    await scheduleDailyReminder(reminderTime);
+  } catch (error) {
+    console.warn('Failed to resync daily reminder:', error);
   }
-
-  if (!(await hasReminderPermission())) {
-    setDailyReminderEnabled(false);
-    await cancelDailyReminder();
-    return;
-  }
-
-  await scheduleDailyReminder(reminderTime);
 }
 
 let remindersInitialized = false;

--- a/apps/mobile/src/lib/reminders.ts
+++ b/apps/mobile/src/lib/reminders.ts
@@ -1,0 +1,221 @@
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+import * as Notifications from 'expo-notifications';
+import { getLocales } from 'expo-localization';
+import { router, type Href } from 'expo-router';
+import { useSettingsStore } from '~/lib/settings';
+import {
+  getEffectiveSupportedLocale,
+  translate,
+  useLocaleStore,
+  type SupportedLocale,
+  type TranslationFunction,
+} from '~/lib/i18n';
+import { getBuiltInJournalPromptTitles } from '~/lib/journalPrompts';
+
+/**
+ * Daily reminder — a single repeating local notification driven by the
+ * `dailyReminderEnabled` / `reminderTime` settings. No push/remote involved.
+ *
+ * Notification text is baked at schedule time, so anything that changes it
+ * (language, focus areas, time) must trigger a reschedule. `resyncReminder()`
+ * runs on every app launch and on language change to keep reality matching
+ * the persisted settings.
+ */
+
+const DAILY_REMINDER_ID = 'daily-reminder';
+const ANDROID_CHANNEL_ID = 'daily-reminder';
+const NEW_ENTRY_ROUTE = '/gratitudeEntry';
+
+function getCurrentLocale(): SupportedLocale {
+  const deviceLocale = getLocales()[0]?.languageTag ?? null;
+  return getEffectiveSupportedLocale(
+    deviceLocale,
+    useLocaleStore.getState().localePreference,
+  );
+}
+
+function parseReminderTime(time: string): { hour: number; minute: number } {
+  const [hourRaw, minuteRaw] = time.split(':');
+  const hour = Number(hourRaw);
+  const minute = Number(minuteRaw);
+  if (
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return { hour: 9, minute: 0 };
+  }
+  return { hour, minute };
+}
+
+function isPermissionGranted(settings: Notifications.NotificationPermissionsStatus) {
+  return (
+    settings.granted ||
+    settings.ios?.status === Notifications.IosAuthorizationStatus.PROVISIONAL
+  );
+}
+
+export async function hasReminderPermission(): Promise<boolean> {
+  return isPermissionGranted(await Notifications.getPermissionsAsync());
+}
+
+/**
+ * Returns true when notifications are (or become) allowed. Safe to call
+ * repeatedly; only prompts while the OS still allows asking.
+ */
+export async function requestReminderPermission(): Promise<boolean> {
+  const existing = await Notifications.getPermissionsAsync();
+  if (isPermissionGranted(existing)) {
+    return true;
+  }
+  if (!existing.canAskAgain) {
+    return false;
+  }
+  return isPermissionGranted(await Notifications.requestPermissionsAsync());
+}
+
+async function ensureAndroidChannel(locale: SupportedLocale) {
+  if (Platform.OS !== 'android') {
+    return;
+  }
+  await Notifications.setNotificationChannelAsync(ANDROID_CHANNEL_ID, {
+    name: translate(locale, 'Daily Reminder'),
+    importance: Notifications.AndroidImportance.DEFAULT,
+  });
+}
+
+function buildReminderContent(locale: SupportedLocale) {
+  const t: TranslationFunction = (key, params) => translate(locale, key, params);
+  const pool = getBuiltInJournalPromptTitles(
+    t,
+    useSettingsStore.getState().journalFocusAreas,
+  );
+  const body =
+    pool.length > 0
+      ? pool[Math.floor(Math.random() * pool.length)]
+      : t('What are you grateful for today?');
+  return {
+    title: t('Daily Reminder'),
+    body,
+    // Carry the prompt into the tap target so the entry editor opens with the
+    // exact question the user tapped, not a fresh random one.
+    data: { url: `${NEW_ENTRY_ROUTE}?promptTitle=${encodeURIComponent(body)}` },
+  };
+}
+
+/**
+ * (Re)schedules the repeating daily reminder at `time` (HH:mm). Uses a fixed
+ * identifier and cancels first, so calling it any number of times leaves
+ * exactly one scheduled reminder.
+ */
+export async function scheduleDailyReminder(time: string): Promise<void> {
+  const { hour, minute } = parseReminderTime(time);
+  const locale = getCurrentLocale();
+  await ensureAndroidChannel(locale);
+  await Notifications.cancelScheduledNotificationAsync(DAILY_REMINDER_ID);
+  await Notifications.scheduleNotificationAsync({
+    identifier: DAILY_REMINDER_ID,
+    content: buildReminderContent(locale),
+    trigger: {
+      type: Notifications.SchedulableTriggerInputTypes.DAILY,
+      hour,
+      minute,
+      channelId: ANDROID_CHANNEL_ID,
+    },
+  });
+}
+
+export async function cancelDailyReminder(): Promise<void> {
+  await Notifications.cancelScheduledNotificationAsync(DAILY_REMINDER_ID);
+}
+
+/**
+ * Makes the OS schedule match the persisted settings. Heals OS reboots,
+ * reinstall-with-restored-settings, missed reschedules, and permission
+ * revoked behind our back (in which case the toggle flips off).
+ */
+export async function resyncReminder(): Promise<void> {
+  const { dailyReminderEnabled, reminderTime, setDailyReminderEnabled } =
+    useSettingsStore.getState();
+
+  if (!dailyReminderEnabled) {
+    await cancelDailyReminder();
+    return;
+  }
+
+  if (!(await hasReminderPermission())) {
+    setDailyReminderEnabled(false);
+    await cancelDailyReminder();
+    return;
+  }
+
+  await scheduleDailyReminder(reminderTime);
+}
+
+let remindersInitialized = false;
+
+/**
+ * One-time bootstrap: suppress the reminder while the app is foregrounded,
+ * resync the schedule with settings, and re-bake notification text when the
+ * language changes. Call once after both settings and locale stores hydrate.
+ */
+export function initReminders(): void {
+  if (remindersInitialized) {
+    return;
+  }
+  remindersInitialized = true;
+
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowBanner: false,
+      shouldShowList: false,
+      shouldPlaySound: false,
+      shouldSetBadge: false,
+    }),
+  });
+
+  useLocaleStore.subscribe((state, prev) => {
+    if (state.localePreference !== prev.localePreference) {
+      void resyncReminder();
+    }
+  });
+
+  void resyncReminder();
+}
+
+function redirectFromNotification(response: Notifications.NotificationResponse | null) {
+  const url = response?.notification.request.content.data?.url;
+  if (typeof url === 'string' && url.startsWith('/')) {
+    router.push(url as Href);
+  }
+}
+
+/**
+ * Navigates to the new-entry screen when the app is opened from a reminder
+ * tap — cold start (last response) and warm/background taps (listener).
+ * Render inside the root navigator so navigation targets a mounted router.
+ */
+export function useReminderTapObserver(): void {
+  useEffect(() => {
+    let isMounted = true;
+
+    Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (isMounted) {
+        redirectFromNotification(response);
+      }
+    });
+
+    const subscription = Notifications.addNotificationResponseReceivedListener(
+      redirectFromNotification,
+    );
+
+    return () => {
+      isMounted = false;
+      subscription.remove();
+    };
+  }, []);
+}

--- a/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryEdit.tsx
+++ b/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryEdit.tsx
@@ -66,6 +66,12 @@ import { WorksheetTemplateModal } from './WorksheetTemplateModal';
 interface GratitudeEntryEditProps {
   initialEntry?: Entry | null;
   initialDateMs?: number;
+  /**
+   * Pre-seeds the prompt title for a new entry (e.g. the prompt shown in the
+   * tapped reminder notification). Takes precedence over the random auto-fill
+   * and counts as a pristine value for unsaved-changes detection.
+   */
+  initialPromptTitle?: string;
   onSaveSuccess: () => void;
   onCancel: () => void;
   onPhotoPress: (photos: Asset[], index: number) => void;
@@ -77,9 +83,37 @@ const areArraysEqual = (a: string[], b: string[]) => {
   return b.every((item) => setA.has(item));
 };
 
-export function GratitudeEntryEdit({
+/**
+ * Thin gate over the edit form. The title auto-fill needs the custom prompt
+ * pool at mount (state initializers only run once), so when the settings
+ * require custom prompts we hold rendering until that local SQLite read
+ * resolves — milliseconds, hidden by the push animation. On query error we
+ * proceed anyway; the pool builder falls back to built-in prompts.
+ */
+export function GratitudeEntryEdit(props: GratitudeEntryEditProps) {
+  const { journalPromptsMode } = useSettingsStore();
+  const { isPending } = useCustomPrompts();
+
+  const willAutoFill =
+    !props.initialEntry && !props.initialPromptTitle && journalPromptsMode !== 'off';
+  const needsCustomPrompts =
+    journalPromptsMode === 'custom' || journalPromptsMode === 'all';
+
+  if (willAutoFill && needsCustomPrompts && isPending) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return <GratitudeEntryEditForm {...props} />;
+}
+
+function GratitudeEntryEditForm({
   initialEntry,
   initialDateMs,
+  initialPromptTitle,
   onSaveSuccess,
   onCancel,
   onPhotoPress,
@@ -88,8 +122,7 @@ export function GratitudeEntryEdit({
   const { t } = useTranslation();
   const navigation = useNavigation();
   const { journalPromptsMode, journalFocusAreas } = useSettingsStore();
-  const { data: customPromptList = [], isSuccess: isCustomPromptsLoaded } =
-    useCustomPrompts();
+  const { data: customPromptList = [] } = useCustomPrompts();
   const customPromptTitles = useMemo(
     () => customPromptList.map((prompt) => prompt.title),
     [customPromptList],
@@ -113,15 +146,33 @@ export function GratitudeEntryEdit({
 
   // Initialize state
   const isNewEntry = !initialEntry;
-  const initialTimestamp = initialEntry?.created_at ?? initialDateMs ?? Date.now();
   const initialTags = initialEntry?.tags
     ? initialEntry.tags.split(',').filter((tag) => tag.length > 0)
     : [];
   const initialPhotos = filterExistingPhotos(initialEntry?.assets ?? null);
   const initialVoiceMemos = filterExistingVoiceMemos(initialEntry?.assets ?? null);
 
-  const [timestamp, setTimestamp] = useState(initialTimestamp);
-  const [title, setTitle] = useState(initialEntry?.text_title || '');
+  // Lazy initializers: Date.now()/Math.random() are impure and must not run
+  // on re-renders (react-hooks/purity) — inside an initializer they run once.
+  const [timestamp, setTimestamp] = useState(
+    () => initialEntry?.created_at ?? initialDateMs ?? Date.now(),
+  );
+  const [title, setTitle] = useState(() => {
+    if (initialEntry?.text_title) return initialEntry.text_title;
+    // A prompt handed in from outside (reminder notification tap) wins over
+    // the random auto-fill.
+    if (initialPromptTitle) return initialPromptTitle;
+    if (!isNewEntry || journalPromptsMode === 'off') return '';
+    // Auto-fill a prompt title per settings. The gate component guarantees
+    // custom prompts are loaded by now when the mode needs them.
+    const pool = getJournalPromptTitlePool({
+      mode: journalPromptsMode,
+      focusAreas: journalFocusAreas,
+      customPromptTitles: customPromptList.map((prompt) => prompt.title),
+      t,
+    });
+    return pool.length > 0 ? (pool[Math.floor(Math.random() * pool.length)] ?? '') : '';
+  });
   const [content, setContent] = useState(initialEntry?.text_content || '');
   const [mood, setMood] = useState<Mood | null>(initialEntry?.mood || null);
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>(initialTags);
@@ -134,40 +185,6 @@ export function GratitudeEntryEdit({
   const titleInputRef = useRef<TextInput>(null);
   const contentInputRef = useRef<TextInput>(null);
   const hasPromptTitle = title.length > 0;
-  const hasAttemptedAutoFill = useRef(false);
-
-  // Auto-fill prompt title for new entries based on settings
-  useEffect(() => {
-    if (!isNewEntry || hasAttemptedAutoFill.current || journalPromptsMode === 'off') {
-      return;
-    }
-
-    const needsCustom = journalPromptsMode === 'custom' || journalPromptsMode === 'all';
-    if (needsCustom && !isCustomPromptsLoaded) {
-      return; // wait until custom prompts are loaded
-    }
-
-    const pool = getJournalPromptTitlePool({
-      mode: journalPromptsMode,
-      focusAreas: journalFocusAreas,
-      customPromptTitles,
-      t,
-    });
-
-    if (pool.length > 0) {
-      const randomPrompt = pool[Math.floor(Math.random() * pool.length)];
-      if (randomPrompt) setTitle(randomPrompt);
-    }
-
-    hasAttemptedAutoFill.current = true;
-  }, [
-    isNewEntry,
-    journalPromptsMode,
-    journalFocusAreas,
-    customPromptTitles,
-    isCustomPromptsLoaded,
-    t,
-  ]);
 
   // Auto-open mood modal for new entries (run once on mount).
   // We wait for 'transitionEnd' so iOS doesn't throw "No presenting view
@@ -227,10 +244,13 @@ export function GratitudeEntryEdit({
     TrueSheet.present(SHEET_NAMES.VOICE_MEMO);
   }, [voiceMemos.length, t]);
 
-  // Original values for change detection
+  // Original values for change detection (initializer runs at mount, so
+  // `timestamp` here is the mount-time value)
   const [originalValues, setOriginalValues] = useState(() => ({
-    timestamp: initialTimestamp,
-    title: initialEntry?.text_title || '',
+    timestamp,
+    // A seeded prompt title is pristine — backing out without typing anything
+    // must not raise the unsaved-changes confirm.
+    title: initialEntry?.text_title || initialPromptTitle || '',
     content: initialEntry?.text_content || '',
     mood: initialEntry?.mood || null,
     tagIds: initialTags,

--- a/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryEdit.tsx
+++ b/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryEdit.tsx
@@ -248,11 +248,11 @@ function GratitudeEntryEditForm({
   // `timestamp` here is the mount-time value)
   const [originalValues, setOriginalValues] = useState(() => ({
     timestamp,
-    // A seeded prompt title is pristine — backing out without typing anything
-    // must not raise the unsaved-changes confirm.
-    title: initialEntry?.text_title || initialPromptTitle || '',
-    content: initialEntry?.text_content || '',
-    mood: initialEntry?.mood || null,
+    // A seeded or auto-filled prompt title is pristine — backing out without
+    // typing anything must not raise the unsaved-changes confirm.
+    title,
+    content,
+    mood,
     tagIds: initialTags,
     photoUris: initialPhotos.map((p) => p.uri),
     voiceMemoUris: initialVoiceMemos.map((m) => m.uri),

--- a/apps/mobile/src/screens/gratitudeEntry/index.tsx
+++ b/apps/mobile/src/screens/gratitudeEntry/index.tsx
@@ -11,11 +11,13 @@ import { GratitudeEntryEdit } from './GratitudeEntryEdit';
 interface IGratitudeEntryProps {
   noteId?: string;
   initialDateMs?: number;
+  initialPromptTitle?: string;
 }
 
 export default function GratitudeEntryScreen({
   noteId,
   initialDateMs,
+  initialPromptTitle,
 }: IGratitudeEntryProps) {
   const [isEditMode, setIsEditMode] = useState(!noteId);
   const router = useRouter();
@@ -48,6 +50,7 @@ export default function GratitudeEntryScreen({
         <GratitudeEntryEdit
           initialEntry={entry}
           initialDateMs={initialDateMs}
+          initialPromptTitle={initialPromptTitle}
           onSaveSuccess={handleEditSaveSuccess}
           onCancel={() => {
             if (noteId) {

--- a/apps/mobile/src/screens/settings/sections/NotificationsSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/NotificationsSection.tsx
@@ -32,9 +32,15 @@ export function NotificationsSection() {
   };
 
   const handleReminderToggle = async () => {
+    // Flip the flag only after the OS call succeeds, so the persisted setting
+    // never diverges from what is actually scheduled.
     if (dailyReminderEnabled) {
-      setDailyReminderEnabled(false);
-      await cancelDailyReminder();
+      try {
+        await cancelDailyReminder();
+        setDailyReminderEnabled(false);
+      } catch {
+        toast.error(t('Failed to update reminder'));
+      }
       return;
     }
 
@@ -52,14 +58,22 @@ export function NotificationsSection() {
       return;
     }
 
-    setDailyReminderEnabled(true);
-    await scheduleDailyReminder(reminderTime);
+    try {
+      await scheduleDailyReminder(reminderTime);
+      setDailyReminderEnabled(true);
+    } catch {
+      toast.error(t('Failed to update reminder'));
+    }
   };
 
   const handleReminderTimeChange = (time: string) => {
+    const previousTime = reminderTime;
     setReminderTime(time);
     if (dailyReminderEnabled) {
-      void scheduleDailyReminder(time);
+      scheduleDailyReminder(time).catch(() => {
+        setReminderTime(previousTime);
+        toast.error(t('Failed to update reminder'));
+      });
     }
   };
 

--- a/apps/mobile/src/screens/settings/sections/NotificationsSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/NotificationsSection.tsx
@@ -1,10 +1,16 @@
 import { useState } from 'react';
-import { View } from 'react-native';
+import { Linking, View } from 'react-native';
 import { Bell, Clock } from 'lucide-react-native';
 import { useTranslation } from '~/lib/i18n';
 import { useSettingsStore } from '~/lib/settings';
+import {
+  cancelDailyReminder,
+  requestReminderPermission,
+  scheduleDailyReminder,
+} from '~/lib/reminders';
 import { Text } from '~/components/ui/text';
 import { Switch } from '~/components/ui/switch';
+import { toast } from '~/components/ui/toast';
 import { TimePickerModal } from '~/components/TimePickerModal';
 import { SettingsSection } from '../SettingsSection';
 import { SettingsRow } from '../SettingsRow';
@@ -25,6 +31,38 @@ export function NotificationsSection() {
     return `${hours.padStart(2, '0')}:${minutes.padStart(2, '0')}`;
   };
 
+  const handleReminderToggle = async () => {
+    if (dailyReminderEnabled) {
+      setDailyReminderEnabled(false);
+      await cancelDailyReminder();
+      return;
+    }
+
+    const granted = await requestReminderPermission();
+    if (!granted) {
+      toast.warning(t('Notification permission needed'), {
+        description: t(
+          'To get daily reminders, allow notifications for Tackbok in your device settings.',
+        ),
+        action: {
+          label: t('Open Settings'),
+          onPress: () => Linking.openSettings(),
+        },
+      });
+      return;
+    }
+
+    setDailyReminderEnabled(true);
+    await scheduleDailyReminder(reminderTime);
+  };
+
+  const handleReminderTimeChange = (time: string) => {
+    setReminderTime(time);
+    if (dailyReminderEnabled) {
+      void scheduleDailyReminder(time);
+    }
+  };
+
   return (
     <>
       <SettingsSection title={t('Notifications')} className="pt-4">
@@ -36,7 +74,7 @@ export function NotificationsSection() {
               : t('Daily reminder notifications are off')
           }
           icon={Bell}
-          onPress={() => setDailyReminderEnabled(!dailyReminderEnabled)}
+          onPress={() => void handleReminderToggle()}
           rightElement={
             <View pointerEvents="none">
               <Switch checked={dailyReminderEnabled} />
@@ -65,7 +103,7 @@ export function NotificationsSection() {
         visible={showTimePickerModal}
         onClose={() => setShowTimePickerModal(false)}
         value={reminderTime}
-        onValueChange={setReminderTime}
+        onValueChange={handleReminderTimeChange}
         title={t('Adjust Reminder Time')}
       />
     </>


### PR DESCRIPTION
- src/lib/reminders.ts: permission flow, idempotent daily scheduling, resync on launch + language change, foreground suppression, tap navigation
- Notification body samples localized prompts from journalFocusAreas; tapping opens the entry editor with that prompt prefilled as the title
- Settings toggle requests permission contextually; denial reverts the toggle with an "Open Settings" toast
- Fix react-hooks purity/set-state-in-effect errors in GratitudeEntryEdit via lazy state initializers + a custom-prompts load gate
- 2 new i18n keys across all 5 locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable daily reminder notifications with permission requests and automatic rescheduling.
  - Tapping a reminder now opens the correct gratitude entry (with the intended date and prompt).
  - Gratitude entry screens can be prefilled from reminder context.
- **Bug Fixes**
  - Improved reminder startup timing to wait for saved settings and language data before initializing.
  - Reminder enabling/disabling and time changes now use success/failure handling with rollback and user toasts.
- **Localization**
  - Added new notification-permission and reminder error guidance strings (Arabic, English, Hebrew, Simplified Chinese, Traditional Chinese).
- **Tests**
  - Updated iOS CSV picker MIME expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->