### PR TITLE
feat(mobile): consent-gated PostHog analytics with typed event catalog

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaListener } from 'react-native-safe-area-context';
-import { Stack } from 'expo-router';
+import { Stack, usePathname } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
 import * as SystemUI from 'expo-system-ui';
@@ -18,6 +18,7 @@ import migrations from '~/drizzle/migrations';
 import { useSettingsStore } from '~/lib/settings';
 import { useLocaleStore } from '~/lib/i18n';
 import { initReminders, useReminderTapObserver } from '~/lib/reminders';
+import { initAnalytics, trackScreenView } from '~/lib/analytics';
 import { cleanupDeferredBackupZipFiles } from '~/lib/backupExport';
 import { getThemeConfig, DEFAULT_THEME_ID } from '~/lib/theme/themes';
 import { AppLoadingScreen } from '~/components/AppLoadingScreen';
@@ -55,6 +56,16 @@ const queryClient = new QueryClient({
 // mounted router (covers both cold-start and warm notification taps).
 function ReminderNavigationObserver() {
   useReminderTapObserver();
+  return null;
+}
+
+// Maps route changes to screen_viewed events (logical screen names only —
+// no raw paths/params). No-ops entirely while analytics is disabled.
+function ScreenViewObserver() {
+  const pathname = usePathname();
+  useEffect(() => {
+    trackScreenView(pathname);
+  }, [pathname]);
   return null;
 }
 
@@ -103,6 +114,14 @@ export default function Layout() {
       initReminders();
     }
   }, [hasHydrated, localeHasHydrated]);
+
+  // Analytics starts only after hydration so the persisted consent flag
+  // (analyticsEnabled) is trustworthy; it stays fully inert when disabled.
+  useEffect(() => {
+    if (hasHydrated) {
+      initAnalytics();
+    }
+  }, [hasHydrated]);
 
   // Show migration error
   if (error) {
@@ -171,6 +190,7 @@ export default function Layout() {
               />
             </Stack>
             <ReminderNavigationObserver />
+            <ScreenViewObserver />
             <StatusBar style={themeConfig.variant === 'dark' ? 'light' : 'dark'} />
             <Toaster />
             <PortalHost />

--- a/apps/mobile/src/db/queries.ts
+++ b/apps/mobile/src/db/queries.ts
@@ -38,6 +38,24 @@ export async function getAllEntriesGroupByDate(): Promise<Map<number, Entry[]>> 
 }
 
 /**
+ * Get aggregate entry stats (total entries + distinct local-time days with at
+ * least one entry). Used for bucketed analytics — only fetches timestamps.
+ */
+export async function getEntryStats(): Promise<{
+  entryCount: number;
+  daysWithEntries: number;
+}> {
+  const rows = await db.select({ created_at: entries.created_at }).from(entries);
+  // Day boundaries must match the app's timeline grouping (local time), so
+  // dedupe in JS rather than with SQLite's UTC-based date().
+  const days = new Set<number>();
+  rows.forEach((row) => {
+    days.add(startOfDay(new Date(row.created_at)).getTime());
+  });
+  return { entryCount: rows.length, daysWithEntries: days.size };
+}
+
+/**
  * Get a single entry by its note_id
  */
 export async function getEntryById(noteId: string): Promise<Entry | undefined> {

--- a/apps/mobile/src/lib/analytics/events.ts
+++ b/apps/mobile/src/lib/analytics/events.ts
@@ -5,7 +5,7 @@
  * autocapture and session replay are disabled, so if an event is not in this
  * map, it cannot be sent. Keep the Analytics section of the public privacy
  * policy (`apps/website/src/pages/privacy.astro`, tackbok.org/privacy) in
- * sync with this file — it links here as the exhaustive list.
+ * sync with this file.
  *
  * Rules for adding events:
  * - Bucketed values only — never raw text, lengths, dates, or ids that could
@@ -39,6 +39,9 @@ export type AnalyticsEvents = {
     has_photo: boolean;
     has_audio: boolean;
     has_mood: boolean;
+    // Deliberately un-bucketed: entries carry a handful of tags at most
+    // (usually 0-2), so the exact count is too coarse to fingerprint content,
+    // and CountBucket would collapse nearly all values into '1-10'.
     tag_count: number;
     char_bucket: CharBucket;
   };

--- a/apps/mobile/src/lib/analytics/events.ts
+++ b/apps/mobile/src/lib/analytics/events.ts
@@ -1,0 +1,74 @@
+/**
+ * The exhaustive, typed catalog of every analytics event this app can emit.
+ *
+ * This file is the single source of truth for what leaves the device:
+ * autocapture and session replay are disabled, so if an event is not in this
+ * map, it cannot be sent. Keep the Analytics section of the public privacy
+ * policy (`apps/website/src/pages/privacy.astro`, tackbok.org/privacy) in
+ * sync with this file — it links here as the exhaustive list.
+ *
+ * Rules for adding events:
+ * - Bucketed values only — never raw text, lengths, dates, or ids that could
+ *   fingerprint journal content or a person.
+ * - No PII, ever (no names, emails, entry text, file names, precise location).
+ */
+
+export type CharBucket = '0-50' | '51-200' | '200+';
+
+/** Order-of-magnitude bucket for entry counts / journaled-day counts. */
+export type CountBucket = '0' | '1-10' | '11-50' | '51-200' | '200+';
+
+/** Logical screens — derived from the route, never the raw pathname/params. */
+export type ScreenName = 'home' | 'entry_new' | 'entry_view' | 'date_entries' | 'settings';
+
+export type ImportSource = 'tackbok' | 'gratitudeApp' | 'presently';
+
+/**
+ * Event name → payload type. `undefined` means the event carries no payload.
+ */
+export type AnalyticsEvents = {
+  /** Fired once per cold start, only when analytics is already enabled. */
+  app_opened: {
+    entry_bucket: CountBucket;
+    days_journaled_bucket: CountBucket;
+    /** ISO country code from device settings (not IP geolocation), e.g. 'SE'. */
+    device_region: string;
+  };
+  screen_viewed: { screen: ScreenName };
+  entry_created: {
+    has_photo: boolean;
+    has_audio: boolean;
+    has_mood: boolean;
+    tag_count: number;
+    char_bucket: CharBucket;
+  };
+  entry_deleted: undefined;
+  search_used: undefined;
+  theme_changed: { theme: string };
+  language_changed: { locale: string };
+  import_completed: { source: ImportSource; entry_bucket: CountBucket };
+  backup_exported: undefined;
+  reminder_enabled: undefined;
+  reminder_disabled: undefined;
+  // Onboarding funnel — defined now, fired only once the onboarding flow ships
+  // (see z-onboarding-flow.md). Buffered pre-consent, sent only on opt-in.
+  onboarding_step_viewed: { step: string };
+  onboarding_completed: undefined;
+  onboarding_skipped: { step: string };
+};
+
+export type AnalyticsEventName = keyof AnalyticsEvents;
+
+export function toCharBucket(charCount: number): CharBucket {
+  if (charCount <= 50) return '0-50';
+  if (charCount <= 200) return '51-200';
+  return '200+';
+}
+
+export function toCountBucket(count: number): CountBucket {
+  if (count <= 0) return '0';
+  if (count <= 10) return '1-10';
+  if (count <= 50) return '11-50';
+  if (count <= 200) return '51-200';
+  return '200+';
+}

--- a/apps/mobile/src/lib/analytics/index.ts
+++ b/apps/mobile/src/lib/analytics/index.ts
@@ -1,0 +1,175 @@
+/**
+ * Consent-gated analytics wrapper — the ONLY file allowed to import
+ * `posthog-react-native`.
+ *
+ * Privacy contract (public version: tackbok.org/privacy or `apps/website/src/pages/privacy.astro` — keep in sync):
+ * - The SDK is lazily constructed only after `analyticsEnabled === true`.
+ *   Before consent it does not exist in memory, phones nothing home, and
+ *   persists nothing to disk. Never initialize-then-mute.
+ * - `track()` is always safe to call: it no-ops while disabled (or routes to
+ *   the RAM-only pre-consent buffer during onboarding).
+ * - Disable wipes everything: opt-out, drop any queued events, reset the
+ *   anonymous id, shut the SDK down.
+ * - Anonymous person mode only — `identify()` is never called, no PII is ever
+ *   attached to an event.
+ */
+
+import type { PostHog } from 'posthog-react-native';
+import { getLocales } from 'expo-localization';
+import { useSettingsStore } from '~/lib/settings';
+import { getEntryStats } from '~/db/queries';
+import {
+  toCountBucket,
+  type AnalyticsEventName,
+  type AnalyticsEvents,
+  type ScreenName,
+} from './events';
+import {
+  drainPreConsentBuffer,
+  isPreConsentBuffering,
+  pushPreConsentEvent,
+  type AnalyticsEventProps,
+} from './preConsentBuffer';
+
+export { startPreConsentBuffering, stopPreConsentBuffering } from './preConsentBuffer';
+export { toCharBucket, toCountBucket } from './events';
+
+// PostHog project API keys are public by design (they can only ingest events,
+// never read data), so committing this is normal for a FOSS app.
+const POSTHOG_API_KEY = 'phc_7mxfX8NwwP9KA8MUqN5QLhnpYtVeBYdK5WJ3qwvLHyl';
+const POSTHOG_HOST = 'https://eu.i.posthog.com';
+
+let client: PostHog | null = null;
+let initialized = false;
+
+// Enable/disable/flush are async and can be toggled rapidly from Settings;
+// serializing them through one chain prevents interleaved init/shutdown.
+let opChain: Promise<void> = Promise.resolve();
+function enqueue(op: () => Promise<void>): Promise<void> {
+  opChain = opChain.then(op).catch((error) => {
+    console.warn('Analytics operation failed:', error);
+  });
+  return opChain;
+}
+
+async function enable(): Promise<void> {
+  if (client) return;
+  // Dynamic import so the SDK is not even loaded into memory pre-consent.
+  const { PostHog } = await import('posthog-react-native');
+  const instance = new PostHog(POSTHOG_API_KEY, {
+    host: POSTHOG_HOST,
+    // Manual events only — the catalog in ./events.ts must stay exhaustive
+    // and truthful, so everything automatic is off.
+    captureAppLifecycleEvents: false,
+    enableSessionReplay: false,
+    // Anonymous person mode: we never call identify(), so no person profiles
+    // are ever created.
+    personProfiles: 'identified_only',
+    // No feature flags / surveys / error tracking — avoids their network
+    // calls entirely.
+    preloadFeatureFlags: false,
+    disableRemoteFeatureFlags: true,
+    disableSurveys: true,
+    // Do not resolve IP to city-level geolocation on ingestion.
+    disableGeoip: true,
+  });
+  await instance.optIn();
+  client = instance;
+}
+
+async function disable(): Promise<void> {
+  if (!client) return;
+  const instance = client;
+  client = null; // track() becomes a no-op immediately
+  const { PostHogPersistedProperty } = await import('posthog-react-native');
+  await instance.optOut();
+  // Drop any queued-but-unsent events so shutdown's final flush sends nothing.
+  instance.setPersistedProperty(PostHogPersistedProperty.Queue, null);
+  instance.reset(); // wipes the anonymous id + super properties
+  await instance.shutdown();
+}
+
+async function captureAppOpened(): Promise<void> {
+  try {
+    const stats = await getEntryStats();
+    client?.capture('app_opened', {
+      entry_bucket: toCountBucket(stats.entryCount),
+      days_journaled_bucket: toCountBucket(stats.daysWithEntries),
+      // Country from device settings — coarse, user-controlled, and avoids
+      // IP geolocation (disableGeoip stays on).
+      device_region: getLocales()[0]?.regionCode ?? 'unknown',
+    });
+  } catch (error) {
+    console.warn('Failed to capture app_opened:', error);
+  }
+}
+
+/**
+ * Bootstraps analytics from persisted settings and reacts to the Settings
+ * toggle at runtime. Call once on app launch, after settings hydration.
+ */
+export function initAnalytics(): void {
+  if (initialized) return;
+  initialized = true;
+
+  if (useSettingsStore.getState().analyticsEnabled) {
+    enqueue(enable);
+    enqueue(captureAppOpened);
+  }
+
+  useSettingsStore.subscribe((state, prevState) => {
+    if (state.analyticsEnabled === prevState.analyticsEnabled) return;
+    if (state.analyticsEnabled) {
+      enqueue(enable);
+    } else {
+      enqueue(disable);
+    }
+  });
+}
+
+type TrackArgs<E extends AnalyticsEventName> = AnalyticsEvents[E] extends undefined
+  ? [event: E]
+  : [event: E, props: AnalyticsEvents[E]];
+
+/**
+ * Records an event from the typed catalog. Always safe to call: no-ops when
+ * analytics is disabled, routes to the RAM-only buffer while the onboarding
+ * consent flow is active.
+ */
+export function track<E extends AnalyticsEventName>(
+  ...[event, props]: TrackArgs<E>
+): void {
+  if (!client && isPreConsentBuffering()) {
+    pushPreConsentEvent(event, props as AnalyticsEventProps | undefined);
+    return;
+  }
+  client?.capture(event, props as AnalyticsEventProps | undefined);
+}
+
+/** Route pathname → screen_viewed event; unknown routes are never sent. */
+export function trackScreenView(pathname: string): void {
+  let screen: ScreenName | null = null;
+  if (pathname === '/') screen = 'home';
+  else if (pathname === '/gratitudeEntry') screen = 'entry_new';
+  else if (pathname.startsWith('/gratitudeEntry/')) screen = 'entry_view';
+  else if (pathname.startsWith('/dateEntries')) screen = 'date_entries';
+  else if (pathname.startsWith('/settings')) screen = 'settings';
+  if (screen) track('screen_viewed', { screen });
+}
+
+/**
+ * Called by onboarding when the user explicitly accepts analytics (after
+ * `setAnalyticsEnabled(true)`): flushes the pre-consent buffer with original
+ * timestamps. The anonymous id is created here, at flush time — buffered
+ * events never had one.
+ */
+export function commitPreConsentBuffer(): Promise<void> {
+  return enqueue(async () => {
+    await enable();
+    for (const buffered of drainPreConsentBuffer()) {
+      client?.capture(buffered.event, buffered.props, {
+        timestamp: buffered.timestamp,
+      });
+    }
+  });
+}

--- a/apps/mobile/src/lib/analytics/index.ts
+++ b/apps/mobile/src/lib/analytics/index.ts
@@ -42,6 +42,16 @@ const POSTHOG_HOST = 'https://eu.i.posthog.com';
 let client: PostHog | null = null;
 let initialized = false;
 
+// Events tracked after consent but while the async SDK construction is still
+// in flight (e.g. the first screen_viewed on an analytics-enabled cold start).
+// RAM-only: flushed once `enable()` finishes, dropped by `disable()`. Capped
+// as a leak guard in case initialization never completes.
+const MAX_INIT_PENDING_EVENTS = 20;
+let initPendingEvents: {
+  event: AnalyticsEventName;
+  props?: AnalyticsEventProps;
+}[] = [];
+
 // Enable/disable/flush are async and can be toggled rapidly from Settings;
 // serializing them through one chain prevents interleaved init/shutdown.
 let opChain: Promise<void> = Promise.resolve();
@@ -75,12 +85,16 @@ async function enable(): Promise<void> {
   });
   await instance.optIn();
   client = instance;
+  for (const pending of initPendingEvents.splice(0)) {
+    instance.capture(pending.event, pending.props);
+  }
 }
 
 async function disable(): Promise<void> {
   if (!client) return;
   const instance = client;
   client = null; // track() becomes a no-op immediately
+  initPendingEvents = [];
   const { PostHogPersistedProperty } = await import('posthog-react-native');
   await instance.optOut();
   // Drop any queued-but-unsent events so shutdown's final flush sends nothing.
@@ -134,16 +148,27 @@ type TrackArgs<E extends AnalyticsEventName> = AnalyticsEvents[E] extends undefi
 /**
  * Records an event from the typed catalog. Always safe to call: no-ops when
  * analytics is disabled, routes to the RAM-only buffer while the onboarding
- * consent flow is active.
+ * consent flow is active, and queues events while consent is granted but the
+ * SDK is still initializing (so nothing is dropped on an enabled cold start).
  */
 export function track<E extends AnalyticsEventName>(
   ...[event, props]: TrackArgs<E>
 ): void {
-  if (!client && isPreConsentBuffering()) {
-    pushPreConsentEvent(event, props as AnalyticsEventProps | undefined);
+  if (!client) {
+    if (isPreConsentBuffering()) {
+      pushPreConsentEvent(event, props as AnalyticsEventProps | undefined);
+    } else if (
+      useSettingsStore.getState().analyticsEnabled &&
+      initPendingEvents.length < MAX_INIT_PENDING_EVENTS
+    ) {
+      initPendingEvents.push({
+        event,
+        props: props as AnalyticsEventProps | undefined,
+      });
+    }
     return;
   }
-  client?.capture(event, props as AnalyticsEventProps | undefined);
+  client.capture(event, props as AnalyticsEventProps | undefined);
 }
 
 /** Route pathname → screen_viewed event; unknown routes are never sent. */

--- a/apps/mobile/src/lib/analytics/preConsentBuffer.ts
+++ b/apps/mobile/src/lib/analytics/preConsentBuffer.ts
@@ -1,0 +1,69 @@
+/**
+ * In-memory (RAM-only) buffer for events emitted before a consent decision.
+ *
+ * Privacy contract:
+ * - Never persisted to disk, never transmitted. If the app is killed before a
+ *   consent decision, the data ceases to exist — there is no pre-consent
+ *   footprint on the device between sessions.
+ * - Buffering is active only while the onboarding flow is mounted.
+ * - On consent accept, events are flushed to PostHog with their original
+ *   timestamps (see `commitPreConsentBuffer` in `./index`). On decline — or
+ *   any exit that is not an explicit accept — the buffer is cleared
+ *   immediately.
+ * - Buffered events carry no identifier; the anonymous id is created by the
+ *   SDK only after consent, at flush time.
+ */
+
+import type { AnalyticsEventName } from './events';
+
+/** All catalog payloads are flat primitive maps (JSON-safe by construction). */
+export type AnalyticsEventProps = Record<string, string | number | boolean>;
+
+export type BufferedAnalyticsEvent = {
+  event: AnalyticsEventName;
+  props?: AnalyticsEventProps;
+  timestamp: Date;
+};
+
+// Leak guard, not a feature: onboarding produces far fewer events than this.
+const MAX_BUFFERED_EVENTS = 50;
+
+let buffer: BufferedAnalyticsEvent[] = [];
+let buffering = false;
+
+/** Call when the onboarding flow mounts. */
+export function startPreConsentBuffering(): void {
+  buffering = true;
+}
+
+/**
+ * Call on decline or any non-accept exit from onboarding.
+ * Clears immediately — decline must not be lazy.
+ */
+export function stopPreConsentBuffering(): void {
+  buffering = false;
+  buffer = [];
+}
+
+export function isPreConsentBuffering(): boolean {
+  return buffering;
+}
+
+export function pushPreConsentEvent(
+  event: AnalyticsEventName,
+  props?: AnalyticsEventProps,
+): void {
+  if (!buffering) return;
+  if (buffer.length >= MAX_BUFFERED_EVENTS) {
+    buffer.shift(); // drop-oldest
+  }
+  buffer.push({ event, props, timestamp: new Date() });
+}
+
+/** Returns all buffered events, clearing the buffer and ending buffering. */
+export function drainPreConsentBuffer(): BufferedAnalyticsEvent[] {
+  const drained = buffer;
+  buffer = [];
+  buffering = false;
+  return drained;
+}

--- a/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryEdit.tsx
+++ b/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryEdit.tsx
@@ -34,6 +34,7 @@ import { usePhotoSession } from '~/hooks/usePhotoSession';
 import { useVoiceMemoSession } from '~/hooks/useVoiceMemoSession';
 import { useWorksheetTemplate } from '~/hooks/useWorksheetTemplate';
 import { useSettingsStore } from '~/lib/settings';
+import { track, toCharBucket } from '~/lib/analytics';
 import { getJournalPromptTitlePool } from '~/lib/journalPrompts';
 import { Text } from '~/components/ui/text';
 import { Button } from '~/components/ui/button';
@@ -332,6 +333,13 @@ function GratitudeEntryEditForm({
       commitRemovedVoiceMemos();
 
       if (isNewEntry) {
+        track('entry_created', {
+          has_photo: photos.length > 0,
+          has_audio: voiceMemos.length > 0,
+          has_mood: mood !== null,
+          tag_count: selectedTagIds.length,
+          char_bucket: toCharBucket(title.trim().length + content.trim().length),
+        });
         toast.success(t('Entry saved successfully'));
       }
       onSaveSuccess();

--- a/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryView.tsx
+++ b/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryView.tsx
@@ -6,6 +6,7 @@ import type { Entry, Asset } from '~/types';
 import { filterExistingPhotos } from '~/lib/photoUtils';
 import { filterExistingVoiceMemos } from '~/lib/voiceMemoUtils';
 import { useTranslation, formatLocalizedDate, formatTimeLabel } from '~/lib/i18n';
+import { track } from '~/lib/analytics';
 import { useTagMapping, useDeleteEntry } from '~/hooks/useGratitude';
 import { Text } from '~/components/ui/text';
 import { toast } from '~/components/ui/toast';
@@ -75,6 +76,7 @@ export function GratitudeEntryView({
     try {
       if (entry.note_id) {
         await deleteEntryMutation.mutateAsync(entry.note_id);
+        track('entry_deleted');
       }
     } catch (error) {
       console.error('Failed to delete entry', error);

--- a/apps/mobile/src/screens/home/SearchResults.tsx
+++ b/apps/mobile/src/screens/home/SearchResults.tsx
@@ -3,6 +3,7 @@ import { View, ActivityIndicator } from 'react-native';
 import { LegendList } from '@legendapp/list/react-native';
 import { type Entry } from '~/types';
 import { useTranslation } from '~/lib/i18n';
+import { track } from '~/lib/analytics';
 import { useSearchEntries } from '~/hooks/useGratitude';
 import { Text } from '~/components/ui/text';
 import { SearchResultItem } from './SearchResultItem';
@@ -24,6 +25,15 @@ export const SearchResults: React.FC<ISearchResultsProps> = ({
     error,
     isLoading,
   } = useSearchEntries(searchQuery, selectedTagIds);
+
+  // One search_used per search session (mount), not per keystroke.
+  const hasTrackedSearch = React.useRef(false);
+  React.useEffect(() => {
+    if (!hasTrackedSearch.current && (searchQuery.trim() || selectedTagIds.length > 0)) {
+      hasTrackedSearch.current = true;
+      track('search_used');
+    }
+  }, [searchQuery, selectedTagIds]);
 
   // Show prompt to search when no query and no tags selected
   if (!searchQuery.trim() && selectedTagIds.length === 0) {

--- a/apps/mobile/src/screens/settings/SettingsLanguageComp.tsx
+++ b/apps/mobile/src/screens/settings/SettingsLanguageComp.tsx
@@ -3,6 +3,7 @@ import { I18nManager, Platform } from 'react-native';
 import { reloadAppAsync } from 'expo';
 import { Languages } from 'lucide-react-native';
 import { useTranslation, languages, type LanguageInfo } from '~/lib/i18n';
+import { track } from '~/lib/analytics';
 import { Text } from '~/components/ui/text';
 import {
   Select,
@@ -90,6 +91,7 @@ export default function SettingsLanguageComp({ isLast = false }: { isLast?: bool
     } else {
       // Apply change immediately
       setLocale(lang.code);
+      track('language_changed', { locale: lang.code });
     }
   };
 
@@ -98,6 +100,7 @@ export default function SettingsLanguageComp({ isLast = false }: { isLast?: bool
     const shouldBeRTL = pendingLanguage.isRTL;
     // Update the locale preference
     setLocale(pendingLanguage.code);
+    track('language_changed', { locale: pendingLanguage.code });
 
     // Close the dialog first, then reload after a short delay.
     // reloadAppAsync() fires synchronously, so if we call it before

--- a/apps/mobile/src/screens/settings/ThemePickerSheet.tsx
+++ b/apps/mobile/src/screens/settings/ThemePickerSheet.tsx
@@ -12,6 +12,7 @@ import { ScopedTheme, useCSSVariable } from 'uniwind';
 import { SHEET_NAMES } from '~/constants';
 import { useTranslation } from '~/lib/i18n';
 import { useSettingsStore } from '~/lib/settings';
+import { track } from '~/lib/analytics';
 import {
   THEMES,
   DEFAULT_THEME_SHEET_RADIUS,
@@ -210,6 +211,7 @@ export function ThemePickerSheet() {
                 onSelect={() => {
                   setTheme(theme.id);
                   setShowTimelineBorders(theme.enableTimelineBorders);
+                  track('theme_changed', { theme: theme.id });
                 }}
               />
             ))}

--- a/apps/mobile/src/screens/settings/sections/BackupRestoreSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/BackupRestoreSection.tsx
@@ -23,6 +23,7 @@ import {
   type ImportMode,
 } from '~/lib/backupImport';
 import { exportToBackupZip } from '~/lib/backupExport';
+import { track, toCountBucket } from '~/lib/analytics';
 import { Text } from '~/components/ui/text';
 import { Switch } from '~/components/ui/switch';
 import { toast } from '~/components/ui/toast';
@@ -92,6 +93,7 @@ export function BackupRestoreSection() {
   const handleExportBackup = useCallback(async () => {
     try {
       await exportToBackupZip();
+      track('backup_exported');
       toast.success(t('Backup exported successfully'));
     } catch (error) {
       const message = error instanceof Error ? error.message : t('Export failed');
@@ -118,6 +120,10 @@ export function BackupRestoreSection() {
 
       setImportProgress(null);
       setImportSummary({ source, summary });
+      track('import_completed', {
+        source,
+        entry_bucket: toCountBucket(summary.importedEntries + summary.updatedEntries),
+      });
     },
     [queryClient],
   );

--- a/apps/mobile/src/screens/settings/sections/NotificationsSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/NotificationsSection.tsx
@@ -8,6 +8,7 @@ import {
   requestReminderPermission,
   scheduleDailyReminder,
 } from '~/lib/reminders';
+import { track } from '~/lib/analytics';
 import { Text } from '~/components/ui/text';
 import { Switch } from '~/components/ui/switch';
 import { toast } from '~/components/ui/toast';
@@ -38,6 +39,7 @@ export function NotificationsSection() {
       try {
         await cancelDailyReminder();
         setDailyReminderEnabled(false);
+        track('reminder_disabled');
       } catch {
         toast.error(t('Failed to update reminder'));
       }
@@ -61,6 +63,7 @@ export function NotificationsSection() {
     try {
       await scheduleDailyReminder(reminderTime);
       setDailyReminderEnabled(true);
+      track('reminder_enabled');
     } catch {
       toast.error(t('Failed to update reminder'));
     }

--- a/apps/website/src/pages/privacy.astro
+++ b/apps/website/src/pages/privacy.astro
@@ -3,7 +3,7 @@ import Layout from '~/layouts/main.astro';
 
 const title = 'Privacy Policy — Tackbok';
 const description = "Learn how Tackbok handles your data. Your journal entries stay on your device — we don't collect or store them.";
-const lastUpdated = 'March 13, 2026';
+const lastUpdated = 'July 22, 2026';
 const supportEmail = 'tackbok.support@mehra.dev';
 ---
 
@@ -50,12 +50,15 @@ const supportEmail = 'tackbok.support@mehra.dev';
           We want to be absolutely clear: <strong>we (the developers) do not have any access to your Google Drive data, your journal entries, or your backup files.</strong> All data is transferred directly between your device and your personal Google Drive account. We do not store your Google Drive credentials or any journal data on our servers, nor do we share your Google user data with any third parties. This integration is provided solely for your convenience to keep your data safe.
         </p>
 
-        <h2 class="text-xl font-semibold tracking-tight border-t border-border pt-4">Analytics</h2>
+        <h2 class="text-xl font-semibold tracking-tight border-t border-border pt-4">Analytics (Opt-In, Off by Default)</h2>
         <p>
-          We use <strong>PostHog</strong> to collect and analyze anonymized usage data and crash reports to understand usage patterns, diagnose issues, and improve our application. The application does not collect any personal data that directly identifies you, such as your name, email, or anything you type within the app.
+          We use <strong>PostHog</strong>, hosted in the <strong>European Union</strong>, to understand how the app is used and improve it. Analytics is <strong>disabled by default</strong>: it only runs if you explicitly turn on the Analytics toggle in the app's settings. Until you do, the analytics code is never even initialized and nothing is sent from your device. If you turn the toggle off again, data collection stops immediately, any unsent events are deleted, and the anonymous identifier is discarded.
         </p>
         <p>
-          The analytics service automatically collects certain information that does not personally identify our end users, such as device state information, unique device identifiers, device hardware and OS information, or anonymized IP addresses.
+          When enabled, analytics is anonymous. Events are linked only to a randomly generated identifier — we never collect your name, your email, or anything you write in the app (no journal text, photos, audio, or tag names). Where a number could hint at your journal's contents, such as an entry's length or how many entries you have, the app reports a coarse range (for example "51–200") instead of the exact value.
+        </p>
+        <p>
+          The app sends only a small, fixed list of events: app opened, screen viewed (screen name only), entry created or deleted (with yes/no flags like "has a photo" — never the content), search used (never the search text), theme or language changed, backup exported or imported, and daily reminder turned on or off. Alongside these, the analytics library reports basic device information (device model, operating system version, app version) and the country configured in your device settings. We do not use IP addresses to determine your location, and automatic capture features such as session recording are disabled. Tackbok is open source, so you can inspect the exhaustive, always-up-to-date event list <a href="https://github.com/mehradotdev/tackbok/blob/main/apps/mobile/src/lib/analytics/events.ts" target="_blank" rel="noopener noreferrer" class="underline underline-offset-4">directly in the source code</a>.
         </p>
 
         <h2 class="text-xl font-semibold tracking-tight border-t border-border pt-4">Data Sharing and Disclosure</h2>
@@ -72,7 +75,7 @@ const supportEmail = 'tackbok.support@mehra.dev';
         </p>
         <ul>
           <li>
-            <strong>PostHog</strong>: This service helps us collect and analyze anonymized usage data and crash reports to improve our app. For more information, please view the <a href="https://posthog.com/privacy" target="_blank" rel="noopener noreferrer" class="underline underline-offset-4">PostHog Privacy Policy</a>.
+            <strong>PostHog</strong>: This service helps us collect and analyze anonymized, opt-in usage data to improve our app (see the Analytics section above). For more information, please view the <a href="https://posthog.com/privacy" target="_blank" rel="noopener noreferrer" class="underline underline-offset-4">PostHog Privacy Policy</a>.
           </li>
           <li>
             <strong>RevenueCat</strong>: This service manages and processes in-app purchases and donations. For more information, please view the <a href="https://www.revenuecat.com/privacy" target="_blank" rel="noopener noreferrer" class="underline underline-offset-4">RevenueCat Privacy Policy</a>.

--- a/apps/website/src/pages/privacy.astro
+++ b/apps/website/src/pages/privacy.astro
@@ -52,15 +52,11 @@ const supportEmail = 'tackbok.support@mehra.dev';
 
         <h2 class="text-xl font-semibold tracking-tight border-t border-border pt-4">Analytics (Opt-In, Off by Default)</h2>
         <p>
-          We use <strong>PostHog</strong>, hosted in the <strong>European Union</strong>, to understand how the app is used and improve it. Analytics is <strong>disabled by default</strong>: it only runs if you explicitly turn on the Analytics toggle in the app's settings. Until you do, the analytics code is never even initialized and nothing is sent from your device. If you turn the toggle off again, data collection stops immediately, any unsent events are deleted, and the anonymous identifier is discarded.
+          We use <strong>PostHog</strong>, hosted in the <strong>European Union</strong>, to understand how the app is used and improve it. Analytics is <strong>disabled by default</strong>: it only runs after you explicitly opt in, via the Analytics toggle in the app's settings. Until you do, the PostHog analytics library is never even loaded or initialized and nothing is sent from your device. If you turn the toggle off again, data collection stops immediately, any unsent events are deleted, and the anonymous identifier is discarded.
         </p>
         <p>
           When enabled, analytics is anonymous. Events are linked only to a randomly generated identifier — we never collect your name, your email, or anything you write in the app (no journal text, photos, audio, or tag names). Where a number could hint at your journal's contents, such as an entry's length or how many entries you have, the app reports a coarse range (for example "51–200") instead of the exact value.
         </p>
-        <p>
-          The app sends only a small, fixed list of events: app opened, screen viewed (screen name only), entry created or deleted (with yes/no flags like "has a photo" — never the content), search used (never the search text), theme or language changed, backup exported or imported, and daily reminder turned on or off. Alongside these, the analytics library reports basic device information (device model, operating system version, app version) and the country configured in your device settings. We do not use IP addresses to determine your location, and automatic capture features such as session recording are disabled. Tackbok is open source, so you can inspect the exhaustive, always-up-to-date event list <a href="https://github.com/mehradotdev/tackbok/blob/main/apps/mobile/src/lib/analytics/events.ts" target="_blank" rel="noopener noreferrer" class="underline underline-offset-4">directly in the source code</a>.
-        </p>
-
         <h2 class="text-xl font-semibold tracking-tight border-t border-border pt-4">Data Sharing and Disclosure</h2>
         <p>
           <strong>We do not sell your personal data.</strong> Any data that is transmitted from your device to our third-party service providers (such as PostHog or RevenueCat) is used strictly to provide, maintain, and improve the app's functionality (e.g., processing donations and analyzing app usage). We do not share your information with any third parties for their own marketing or advertising purposes.


### PR DESCRIPTION
privacy-respecting product analytics that is fully inert until the existing analyticsEnabled Settings toggle is on.

- src/lib/analytics/index.ts: lazy singleton wrapper (only file allowed to import posthog-react-native); SDK is dynamically imported and constructed only after consent, reacts to the toggle at runtime (enable -> init + optIn; disable -> optOut + drop queued events + reset anonymous id + shutdown). EU host, manual events only (no autocapture / replay / lifecycle / flags / surveys / geoip), identify() never called.
- src/lib/analytics/events.ts: exhaustive typed event catalog with bucketed values (never raw text/lengths); includes onboarding funnel events defined now but fired only when onboarding ships.
- src/lib/analytics/preConsentBuffer.ts: RAM-only pre-consent buffer (never persisted or transmitted; drop-oldest cap of 50; cleared on decline; flushed with original timestamps on accept).
- app_opened carries bucketed entry/days-journaled counts via new getEntryStats() query; screen_viewed derives logical screen names from routes (never raw paths/params).
- Instrumented call sites: entry create/delete, search, theme, language, import/export, reminder toggle.
- ANALYTICS.md: human-readable transparency doc, linked from Settings ("What we collect", localized in all 5 locales).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in, off-by-default anonymous analytics for app usage.
  * Added tracking for screen views, entries, searches, settings changes, reminders, backups, and imports.
  * Analytics events remain buffered until consent is granted and are discarded if consent is declined.
* **Documentation**
  * Updated the privacy policy with analytics behavior, collected event categories, and data protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->