### PR TITLE
feat: app lock via OS biometric or device-credential prompt

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -22,6 +22,7 @@ import { initAnalytics, trackScreenView } from '~/lib/analytics';
 import { cleanupDeferredBackupZipFiles } from '~/lib/backupExport';
 import { getThemeConfig, DEFAULT_THEME_ID } from '~/lib/theme/themes';
 import { AppLoadingScreen } from '~/components/AppLoadingScreen';
+import { AppLockGate } from '~/components/AppLockGate';
 import { PortalHost } from '~/components/primitives/portal';
 import { Text } from '~/components/ui/text';
 import { Toaster } from '~/components/ui/toast';
@@ -151,46 +152,48 @@ export default function Layout() {
             Uniwind.updateInsets(insets);
           }}>
           <KeyboardProvider>
-            <Stack
-              screenOptions={{
-                headerShown: false,
-                headerTitleAlign: 'center',
-                headerTintColor: primaryForeground as string,
-                headerStyle: { backgroundColor: primaryColor as string },
-                headerTitleStyle: { fontWeight: 'bold' },
-              }}>
-              <Stack.Screen name="index" />
-              <Stack.Screen
-                name="gratitudeEntry/index"
-                options={{
-                  title: 'Gratitude Entry',
+            <AppLockGate>
+              <Stack
+                screenOptions={{
                   headerShown: false,
-                }}
-              />
-              <Stack.Screen
-                name="gratitudeEntry/[noteId]"
-                options={{
-                  title: 'Gratitude Entry View',
-                  headerShown: false,
-                }}
-              />
-              <Stack.Screen
-                name="dateEntries/[dateMs]"
-                options={{
-                  title: 'Date Entries',
-                  headerShown: false,
-                }}
-              />
-              <Stack.Screen
-                name="settings"
-                options={{
-                  title: 'Settings',
-                  headerShown: false,
-                }}
-              />
-            </Stack>
-            <ReminderNavigationObserver />
-            <ScreenViewObserver />
+                  headerTitleAlign: 'center',
+                  headerTintColor: primaryForeground as string,
+                  headerStyle: { backgroundColor: primaryColor as string },
+                  headerTitleStyle: { fontWeight: 'bold' },
+                }}>
+                <Stack.Screen name="index" />
+                <Stack.Screen
+                  name="gratitudeEntry/index"
+                  options={{
+                    title: 'Gratitude Entry',
+                    headerShown: false,
+                  }}
+                />
+                <Stack.Screen
+                  name="gratitudeEntry/[noteId]"
+                  options={{
+                    title: 'Gratitude Entry View',
+                    headerShown: false,
+                  }}
+                />
+                <Stack.Screen
+                  name="dateEntries/[dateMs]"
+                  options={{
+                    title: 'Date Entries',
+                    headerShown: false,
+                  }}
+                />
+                <Stack.Screen
+                  name="settings"
+                  options={{
+                    title: 'Settings',
+                    headerShown: false,
+                  }}
+                />
+              </Stack>
+              <ReminderNavigationObserver />
+              <ScreenViewObserver />
+            </AppLockGate>
             <StatusBar style={themeConfig.variant === 'dark' ? 'light' : 'dark'} />
             <Toaster />
             <PortalHost />

--- a/apps/mobile/src/components/AppLockGate.tsx
+++ b/apps/mobile/src/components/AppLockGate.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AppState, Modal, View } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { useCSSVariable } from 'uniwind';
 import { useTranslation } from '~/lib/i18n';
 import { useSettingsStore } from '~/lib/settings';
-import { attemptUnlock, useAppLockStore, type AuthPrompt } from '~/lib/appLock';
+import { attemptUnlock, canUseDeviceAuth, useAppLockStore } from '~/lib/appLock';
 import { getThemeConfig } from '~/lib/theme/themes';
 import { TackbokLogo } from '~/components/TackbokLogo';
 import { SafeAreaView } from '~/components/ui/safe-area-view';
@@ -47,10 +47,21 @@ export function AppLockGate({ children }: { children: React.ReactNode }) {
   // via the button. Prevents a cancel → foreground → prompt → cancel loop.
   const autoPromptedRef = useRef(false);
 
-  const unlockPrompt = (): AuthPrompt => ({
-    promptMessage: t('Unlock Tackbok'),
-    cancelLabel: t('Cancel'),
-  });
+  // Re-checks enrollment on every attempt: if the user removed all device
+  // auth (passcode off kills biometrics too) after enabling the lock,
+  // there is nothing left to authenticate against — clear the lock and
+  // turn the setting off instead of trapping them on the lock screen.
+  const tryUnlock = useCallback(async () => {
+    if (await canUseDeviceAuth()) {
+      await attemptUnlock({
+        promptMessage: t('Unlock Tackbok'),
+        cancelLabel: t('Cancel'),
+      });
+    } else {
+      useSettingsStore.getState().setBiometricUnlockEnabled(false);
+      useAppLockStore.getState().unlock();
+    }
+  }, [t]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (next) => {
@@ -70,12 +81,9 @@ export function AppLockGate({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (locked && active && !autoPromptedRef.current) {
       autoPromptedRef.current = true;
-      void attemptUnlock({
-        promptMessage: t('Unlock Tackbok'),
-        cancelLabel: t('Cancel'),
-      });
+      void tryUnlock();
     }
-  }, [locked, active, t]);
+  }, [locked, active, tryUnlock]);
 
   return (
     <>
@@ -83,7 +91,7 @@ export function AppLockGate({ children }: { children: React.ReactNode }) {
       <AppLockScreen
         visible={enabled && (locked || !active)}
         showUnlockButton={locked}
-        onUnlockPress={() => void attemptUnlock(unlockPrompt())}
+        onUnlockPress={() => void tryUnlock()}
       />
     </>
   );

--- a/apps/mobile/src/components/AppLockGate.tsx
+++ b/apps/mobile/src/components/AppLockGate.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { AppState, Modal, View } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { useCSSVariable } from 'uniwind';
+import { useTranslation } from '~/lib/i18n';
+import { useSettingsStore } from '~/lib/settings';
+import { attemptUnlock, useAppLockStore, type AuthPrompt } from '~/lib/appLock';
+import { getThemeConfig } from '~/lib/theme/themes';
+import { TackbokLogo } from '~/components/TackbokLogo';
+import { SafeAreaView } from '~/components/ui/safe-area-view';
+import { Button } from '~/components/ui/button';
+import { Text } from '~/components/ui/text';
+
+/** Square logo — matches `AppLoadingScreen` for a seamless splash → lock handoff. */
+const LOCK_LOGO_SIZE = 108;
+
+/**
+ * Root gate for the app lock. When `biometricUnlockEnabled` is on:
+ * - cold start renders the opaque lock screen instead of app content (no
+ *   flash of journal entries) and auto-triggers the OS auth prompt;
+ * - real backgrounding re-locks; brief `inactive` blips (app switcher peek,
+ *   permission dialogs, the auth sheet itself) do not;
+ * - while the app is not `active` the same opaque screen doubles as a
+ *   task-switcher privacy cover.
+ *
+ * The cover is a native `Modal` so it also hides any native modals
+ * (image viewer, pickers) that would otherwise sit above a plain overlay.
+ */
+export function AppLockGate({ children }: { children: React.ReactNode }) {
+  const { t } = useTranslation();
+  const enabled = useSettingsStore((s) => s.biometricUnlockEnabled);
+  const isLocked = useAppLockStore((s) => s.isLocked);
+  const [appStateStatus, setAppStateStatus] = useState(AppState.currentState);
+
+  // Pre-init `null` counts as locked so content never paints first.
+  const locked = enabled && (isLocked ?? true);
+  const active = appStateStatus === 'active';
+
+  // Once unlocked, keep the app mounted across later locks so navigation and
+  // screen state survive; the opaque modal does the hiding from then on.
+  const [everUnlocked, setEverUnlocked] = useState(!locked);
+  if (!locked && !everUnlocked) {
+    setEverUnlocked(true);
+  }
+
+  // One automatic OS prompt per lock cycle; after a cancel the user retries
+  // via the button. Prevents a cancel → foreground → prompt → cancel loop.
+  const autoPromptedRef = useRef(false);
+
+  const unlockPrompt = (): AuthPrompt => ({
+    promptMessage: t('Unlock Tackbok'),
+    cancelLabel: t('Cancel'),
+  });
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (next) => {
+      setAppStateStatus(next);
+      if (
+        next === 'background' &&
+        useSettingsStore.getState().biometricUnlockEnabled &&
+        !useAppLockStore.getState().isAuthenticating
+      ) {
+        autoPromptedRef.current = false;
+        useAppLockStore.getState().lock();
+      }
+    });
+    return () => subscription.remove();
+  }, []);
+
+  useEffect(() => {
+    if (locked && active && !autoPromptedRef.current) {
+      autoPromptedRef.current = true;
+      void attemptUnlock({
+        promptMessage: t('Unlock Tackbok'),
+        cancelLabel: t('Cancel'),
+      });
+    }
+  }, [locked, active, t]);
+
+  return (
+    <>
+      {everUnlocked ? children : null}
+      <AppLockScreen
+        visible={enabled && (locked || !active)}
+        showUnlockButton={locked}
+        onUnlockPress={() => void attemptUnlock(unlockPrompt())}
+      />
+    </>
+  );
+}
+
+interface AppLockScreenProps {
+  visible: boolean;
+  /** False while the cover is only acting as a privacy screen (not locked). */
+  showUnlockButton: boolean;
+  onUnlockPress: () => void;
+}
+
+function AppLockScreen({ visible, showUnlockButton, onUnlockPress }: AppLockScreenProps) {
+  const { t } = useTranslation();
+  const theme = useSettingsStore((s) => s.theme);
+  const themeConfig = getThemeConfig(theme);
+  const [foregroundColor] = useCSSVariable(['--color-foreground']);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="none"
+      presentationStyle="fullScreen"
+      statusBarTranslucent
+      navigationBarTranslucent
+      onRequestClose={() => {}}>
+      <SafeAreaView
+        className="flex-1 bg-background dark:bg-primary"
+        edges={['top', 'left', 'right', 'bottom']}>
+        <StatusBar style={themeConfig.variant === 'dark' ? 'light' : 'dark'} />
+        <View className="flex-1 items-center justify-center gap-10">
+          <TackbokLogo size={LOCK_LOGO_SIZE} color={foregroundColor as string} />
+          {showUnlockButton ? (
+            <Button variant="primary" size="lg" onPress={onUnlockPress}>
+              <Text>{t('Unlock')}</Text>
+            </Button>
+          ) : null}
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/db/index.ts
+++ b/apps/mobile/src/db/index.ts
@@ -26,7 +26,15 @@ expo.execSync('PRAGMA journal_mode = WAL');
 // per-connection busy_timeout applies to its reads/writes too (journal_mode
 // is persisted in the file either way). Best effort: a failed attempt is
 // retried on next launch.
-void SQLite.openDatabaseAsync(KV_STORE_DATABASE_NAME)
+//
+// The promise must stay reachable for the app's lifetime: on Android,
+// garbage-collecting a JS database handle closes the underlying native
+// connection (NativeDatabase.sharedObjectDidRelease) even though kv-store
+// still uses it, after which every settings write dies with an NPE from
+// prepareAsync. A settled promise strongly references its value, so holding
+// the promise keeps the handle alive.
+const kvStoreDbHandle = SQLite.openDatabaseAsync(KV_STORE_DATABASE_NAME);
+void kvStoreDbHandle
   .then((kvDb) =>
     kvDb.execAsync('PRAGMA busy_timeout = 2000; PRAGMA journal_mode = WAL;'),
   )

--- a/apps/mobile/src/lib/appLock.ts
+++ b/apps/mobile/src/lib/appLock.ts
@@ -1,0 +1,90 @@
+import { create } from 'zustand';
+import * as LocalAuthentication from 'expo-local-authentication';
+
+/**
+ * App lock — gates the UI behind the stock OS authentication prompt when
+ * `biometricUnlockEnabled` is on. Biometrics (Face ID / Touch ID / Android
+ * BiometricPrompt) when enrolled, otherwise the device credential (PIN,
+ * pattern, or passcode) — so users who deliberately don't enroll biometrics
+ * can still lock the app. There is no custom in-app PIN; the OS owns the
+ * entire unlock UX, including attempt lockouts and credential escalation.
+ *
+ * This is a UI gate, not encryption — the SQLite file on disk is
+ * unaffected.
+ */
+
+export interface AuthPrompt {
+  /** Localized title shown on the OS auth sheet. */
+  promptMessage: string;
+  /** Localized cancel button label (Android). */
+  cancelLabel: string;
+}
+
+interface AppLockState {
+  /**
+   * `null` until the first lock/unlock decision after settings hydration.
+   * The gate treats `null` as locked whenever the setting is on, so journal
+   * content is never painted before the first unlock on cold start.
+   */
+  isLocked: boolean | null;
+  /**
+   * True while the OS auth sheet is up. The sheet itself can push the app
+   * to `background` (Android passcode fallback opens a separate activity),
+   * which must not re-trigger the lock.
+   */
+  isAuthenticating: boolean;
+  lock: () => void;
+  unlock: () => void;
+}
+
+export const useAppLockStore = create<AppLockState>()((set) => ({
+  isLocked: null,
+  isAuthenticating: false,
+  lock: () => set({ isLocked: true }),
+  unlock: () => set({ isLocked: false }),
+}));
+
+/**
+ * Device has any secure unlock method set up — biometrics, or a PIN /
+ * pattern / passcode (`SecurityLevel.SECRET`). Either is enough:
+ * `authenticateAsync` falls back to the device credential when no
+ * biometric is enrolled.
+ */
+export async function canUseDeviceAuth(): Promise<boolean> {
+  const level = await LocalAuthentication.getEnrolledLevelAsync();
+  return level !== LocalAuthentication.SecurityLevel.NONE;
+}
+
+/**
+ * Shows the OS authentication prompt (biometric or device credential).
+ * Resolves false on cancel/failure and never throws. Ignores the call
+ * (returns false) if a prompt is already up.
+ */
+export async function authenticate(prompt: AuthPrompt): Promise<boolean> {
+  if (useAppLockStore.getState().isAuthenticating) {
+    return false;
+  }
+  useAppLockStore.setState({ isAuthenticating: true });
+  try {
+    const result = await LocalAuthentication.authenticateAsync({
+      promptMessage: prompt.promptMessage,
+      cancelLabel: prompt.cancelLabel,
+      disableDeviceFallback: false,
+    });
+    return result.success;
+  } catch (error) {
+    console.warn('Biometric authentication failed:', error);
+    return false;
+  } finally {
+    useAppLockStore.setState({ isAuthenticating: false });
+  }
+}
+
+/** Runs the OS prompt and clears the lock on success. */
+export async function attemptUnlock(prompt: AuthPrompt): Promise<boolean> {
+  const success = await authenticate(prompt);
+  if (success) {
+    useAppLockStore.getState().unlock();
+  }
+  return success;
+}

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -321,8 +321,12 @@ export const ar: Translations = {
   // Settings - Security
   Security: 'الأمان',
   'Unlock Tackbok': 'فتح تاكبوك',
-  'Lock with biometric scanner if supported':
-    'يمكن لتاكبوك القفل باستخدام الماسح البيومتري لجهازك (إذا كان مدعوماً)',
+  'Lock with your device screen lock':
+    'يمكن لتاكبوك القفل باستخدام قفل شاشة جهازك — المقاييس الحيوية أو رمز PIN أو النمط أو كلمة المرور',
+  Unlock: 'فتح القفل',
+  'App lock unavailable': 'قفل التطبيق غير متاح',
+  'Set up a screen lock (PIN, pattern, or biometrics) in your device settings first.':
+    'قم أولاً بإعداد قفل الشاشة (رمز PIN أو النمط أو المقاييس الحيوية) في إعدادات جهازك.',
 
   // Settings - Backup & Restore
   'Backup & Restore': 'النسخ الاحتياطي والاستعادة',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -338,8 +338,12 @@ export const en = {
   // Settings - Security
   Security: 'Security',
   'Unlock Tackbok': 'Unlock Tackbok',
-  'Lock with biometric scanner if supported':
-    "Tackbok can lock with your device's biometric scanner (if supported by device)",
+  'Lock with your device screen lock':
+    "Tackbok can lock with your device's screen lock — biometrics, PIN, pattern, or passcode",
+  Unlock: 'Unlock',
+  'App lock unavailable': 'App lock unavailable',
+  'Set up a screen lock (PIN, pattern, or biometrics) in your device settings first.':
+    'Set up a screen lock (PIN, pattern, or biometrics) in your device settings first.',
 
   // Settings - Backup & Restore
   'Backup & Restore': 'Backup & Restore',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -322,8 +322,12 @@ export const he: Translations = {
   // Settings - Security
   Security: 'אבטחה',
   'Unlock Tackbok': 'פתיחת טאקבוק',
-  'Lock with biometric scanner if supported':
-    'טאקבוק יכול לנעול באמצעות הסורק הביומטרי של המכשיר (אם נתמך)',
+  'Lock with your device screen lock':
+    'טאקבוק יכול להינעל באמצעות נעילת המסך של המכשיר — ביומטריה, קוד PIN, קו ביטול נעילה או סיסמה',
+  Unlock: 'ביטול נעילה',
+  'App lock unavailable': 'נעילת האפליקציה אינה זמינה',
+  'Set up a screen lock (PIN, pattern, or biometrics) in your device settings first.':
+    'תחילה יש להגדיר נעילת מסך (קוד PIN, קו ביטול נעילה או ביומטריה) בהגדרות המכשיר.',
 
   // Settings - Backup & Restore
   'Backup & Restore': 'גיבוי ושחזור',

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -314,8 +314,12 @@ export const zhCN: Translations = {
   // Settings - Security
   Security: '安全',
   'Unlock Tackbok': '解锁塔克博克',
-  'Lock with biometric scanner if supported':
-    '塔克博克可使用设备的生物识别扫描仪锁定（如果设备支持）',
+  'Lock with your device screen lock':
+    '塔克博克可使用设备的锁屏方式锁定——生物识别、PIN 码、图案或密码',
+  Unlock: '解锁',
+  'App lock unavailable': '应用锁不可用',
+  'Set up a screen lock (PIN, pattern, or biometrics) in your device settings first.':
+    '请先在设备设置中设置锁屏方式（PIN 码、图案或生物识别）。',
 
   // Settings - Backup & Restore
   'Backup & Restore': '备份与恢复',

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -315,7 +315,12 @@ export const zhTW: Translations = {
   // Settings - Security
   Security: '安全性',
   'Unlock Tackbok': '解鎖塔克博克',
-  'Lock with biometric scanner if supported': '若裝置支援，使用生物辨識鎖定',
+  'Lock with your device screen lock':
+    '可使用裝置的螢幕鎖定方式鎖定塔克博克——生物辨識、PIN 碼、圖形或密碼',
+  Unlock: '解鎖',
+  'App lock unavailable': '應用程式鎖定無法使用',
+  'Set up a screen lock (PIN, pattern, or biometrics) in your device settings first.':
+    '請先在裝置設定中設定螢幕鎖定（PIN 碼、圖形或生物辨識）。',
 
   // Settings - Backup & Restore
   'Backup & Restore': '備份與還原',

--- a/apps/mobile/src/screens/settings/sections/SecuritySection.tsx
+++ b/apps/mobile/src/screens/settings/sections/SecuritySection.tsx
@@ -2,7 +2,9 @@ import { View } from 'react-native';
 import { Fingerprint } from 'lucide-react-native';
 import { useTranslation } from '~/lib/i18n';
 import { useSettingsStore } from '~/lib/settings';
+import { authenticate, canUseDeviceAuth, useAppLockStore } from '~/lib/appLock';
 import { Switch } from '~/components/ui/switch';
+import { toast } from '~/components/ui/toast';
 import { SettingsSection } from '../SettingsSection';
 import { SettingsRow } from '../SettingsRow';
 
@@ -10,14 +12,46 @@ export function SecuritySection() {
   const { t } = useTranslation();
   const { biometricUnlockEnabled, setBiometricUnlockEnabled } = useSettingsStore();
 
+  const handleToggle = async () => {
+    const prompt = {
+      promptMessage: t('Unlock Tackbok'),
+      cancelLabel: t('Cancel'),
+    };
+
+    if (biometricUnlockEnabled) {
+      // Standard hardening: disabling the lock requires proving it's you too.
+      if (await authenticate(prompt)) {
+        setBiometricUnlockEnabled(false);
+        useAppLockStore.getState().unlock();
+      }
+      return;
+    }
+
+    if (!(await canUseDeviceAuth())) {
+      toast.warning(t('App lock unavailable'), {
+        description: t(
+          'Set up a screen lock (PIN, pattern, or biometrics) in your device settings first.',
+        ),
+      });
+      return;
+    }
+
+    // Require one successful authentication before persisting the setting,
+    // so a broken/cancelled prompt can never lock the user out of the app.
+    if (await authenticate(prompt)) {
+      setBiometricUnlockEnabled(true);
+      useAppLockStore.getState().unlock();
+    }
+  };
+
   return (
     <SettingsSection title={t('Security')}>
       <SettingsRow
         label={t('Unlock Tackbok')}
-        description={t('Lock with biometric scanner if supported')}
+        description={t('Lock with your device screen lock')}
         icon={Fingerprint}
         isLast
-        onPress={() => setBiometricUnlockEnabled(!biometricUnlockEnabled)}
+        onPress={() => void handleToggle()}
         rightElement={
           <View pointerEvents="none">
             <Switch checked={biometricUnlockEnabled} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app locking using the device’s screen lock, including biometrics, PIN, pattern, or passcode.
  * The app automatically locks when backgrounded and prompts for authentication when reopened.
  * Added a themed unlock screen with an Unlock button.
  * Updated Security settings with setup guidance and unavailable-state messaging.
  * Added localized app-lock text across supported languages.

* **Bug Fixes**
  * Improved reliability of local database writes by keeping the database connection available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->