### PR TITLE
feat(mobile): add share sheet and honor date style in timeline

### DIFF
--- a/apps/mobile/src/components/GratitudeDatepickerModal.tsx
+++ b/apps/mobile/src/components/GratitudeDatepickerModal.tsx
@@ -2,10 +2,14 @@ import { useState, useMemo, useCallback, useEffect } from 'react';
 import { View } from 'react-native';
 import { format, startOfDay } from 'date-fns';
 import { cn } from 'tailwind-variants';
+import { Shuffle } from 'lucide-react-native';
 import { MODAL_CLOSE_DELAY } from '~/constants';
 import { useSettingsStore } from '~/lib/settings';
-import { useEntryDatesForMonth } from '~/hooks/useGratitude';
+import { useTranslation } from '~/lib/i18n';
+import { useEntryDatesForMonth, useEntryCount } from '~/hooks/useGratitude';
 import { Text } from '~/components/ui/text';
+import { Button } from '~/components/ui/button';
+import { Icon } from '~/components/ui/icon';
 import { Dialog, DialogContent } from '~/components/ui/dialog';
 import { DatePicker, type MarkedDate } from '~/components/ui/datepicker';
 
@@ -18,6 +22,8 @@ export interface IGratitudeDatepickerModalProps {
   entryMarkerColor?: string;
   /** Callback when a date is selected */
   onDateSelect?: (date: Date) => void;
+  /** Callback when the Random button is pressed. Button is hidden when absent or when fewer than 2 entries exist */
+  onRandomSelect?: () => void;
   /** Controlled visibility state */
   visible: boolean;
   /** Callback when modal closes */
@@ -31,9 +37,11 @@ export interface IGratitudeDatepickerModalProps {
 export function GratitudeDatepickerModal({
   entryMarkerColor = '#22c55e', // green-500
   onDateSelect,
+  onRandomSelect,
   visible,
   onClose,
 }: IGratitudeDatepickerModalProps) {
+  const { t } = useTranslation();
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [currentMonthYear, setCurrentMonthYear] = useState(() => {
     const now = new Date();
@@ -47,6 +55,9 @@ export function GratitudeDatepickerModal({
     currentMonthYear.month,
     visible,
   );
+  // "Random" is only meaningful with at least 2 entries to pick between
+  const { data: entryCount = 0 } = useEntryCount(visible);
+  const showRandomButton = !!onRandomSelect && entryCount >= 2;
 
   // Reset state when modal opens
   useEffect(() => {
@@ -102,6 +113,14 @@ export function GratitudeDatepickerModal({
     [onDateSelect, handleOpenChange],
   );
 
+  const handleRandomPress = useCallback(() => {
+    // Close first, then navigate after the close-animation, same as date selection
+    handleOpenChange(false);
+    setTimeout(() => {
+      onRandomSelect?.();
+    }, MODAL_CLOSE_DELAY);
+  }, [onRandomSelect, handleOpenChange]);
+
   // Custom day render — uses isDisabled from DatePicker as the single source of truth
   const renderDay = useCallback(
     (date: Date, isSelected: boolean, isDisabled: boolean, isCurrentMonth: boolean) => {
@@ -152,6 +171,20 @@ export function GratitudeDatepickerModal({
           scrollToBottomYearsView={true}
           onMonthYearChange={handleMonthChange}
           firstDayOfWeek={firstDayOfWeek}
+          footer={
+            showRandomButton ? (
+              <View className="mt-1 flex-row justify-end">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onPress={handleRandomPress}
+                  accessibilityLabel={t('Open a random entry')}>
+                  <Icon as={Shuffle} size={16} />
+                  <Text>{t('Random')}</Text>
+                </Button>
+              </View>
+            ) : undefined
+          }
         />
       </DialogContent>
     </Dialog>

--- a/apps/mobile/src/components/ui/datepicker.tsx
+++ b/apps/mobile/src/components/ui/datepicker.tsx
@@ -78,6 +78,8 @@ export interface DatePickerProps {
   onMonthYearChange?: (date: Date) => void;
   /** First day of the week */
   firstDayOfWeek?: FirstDayOfWeek;
+  /** Optional content rendered below the calendar (e.g. action buttons) */
+  footer?: React.ReactNode;
 }
 
 type ViewMode = 'days' | 'months' | 'years';
@@ -212,6 +214,7 @@ export function DatePicker({
   scrollToBottomYearsView = false,
   onMonthYearChange,
   firstDayOfWeek = FirstDay.MONDAY,
+  footer,
 }: DatePickerProps) {
   const { t, isRTL } = useTranslation();
   const [viewDate, setViewDate] = useState(value);
@@ -549,6 +552,7 @@ export function DatePicker({
       {viewMode === 'days' && renderDaysView()}
       {viewMode === 'months' && renderMonthsView()}
       {viewMode === 'years' && renderYearsView()}
+      {viewMode === 'days' && footer}
     </View>
   );
 }

--- a/apps/mobile/src/db/queries.ts
+++ b/apps/mobile/src/db/queries.ts
@@ -65,6 +65,27 @@ export async function hasAnyEntries(): Promise<boolean> {
 }
 
 /**
+ * Total number of entries. Used to decide whether the datepicker's
+ * "Random" shortcut is worth showing (hidden below 2 entries).
+ */
+export async function getEntryCount(): Promise<number> {
+  const [row] = await db.select({ count: sql<number>`count(*)` }).from(entries);
+  return row?.count ?? 0;
+}
+
+/**
+ * Get the note_id of one random entry
+ */
+export async function getRandomEntryId(): Promise<string | undefined> {
+  const [row] = await db
+    .select({ note_id: entries.note_id })
+    .from(entries)
+    .orderBy(sql`RANDOM()`)
+    .limit(1);
+  return row?.note_id;
+}
+
+/**
  * Get a single entry by its note_id
  */
 export async function getEntryById(noteId: string): Promise<Entry | undefined> {

--- a/apps/mobile/src/hooks/useGratitude.ts
+++ b/apps/mobile/src/hooks/useGratitude.ts
@@ -85,12 +85,13 @@ export function useEntryCount(enabled = true) {
 }
 
 /**
- * Hook for a single entry
+ * Hook for a single entry. Resolves `null` when the entry does not exist —
+ * React Query v5 treats `undefined` query data as an error and would retry.
  */
 export function useEntry(noteId?: string) {
   return useQuery({
     queryKey: [QUERY_KEYS.entries, 'byEntry', noteId],
-    queryFn: () => (noteId ? getEntryById(noteId) : Promise.resolve(undefined)),
+    queryFn: async () => (noteId ? ((await getEntryById(noteId)) ?? null) : null),
     enabled: !!noteId,
   });
 }

--- a/apps/mobile/src/hooks/useGratitude.ts
+++ b/apps/mobile/src/hooks/useGratitude.ts
@@ -5,6 +5,7 @@ import { useSettingsStore } from '~/lib/settings';
 import {
   getAllEntries,
   getEntriesForDay,
+  getEntryCount,
   getEntryDatesForMonth,
   searchEntries,
   getAllTags,
@@ -68,6 +69,17 @@ export function useEntryDatesForMonth(year: number, month: number, enabled = tru
   return useQuery<string[]>({
     queryKey: [QUERY_KEYS.entries, 'datesByMonth', year, month],
     queryFn: () => getEntryDatesForMonth(year, month),
+    enabled,
+  });
+}
+
+/**
+ * Hook for the total entry count
+ */
+export function useEntryCount(enabled = true) {
+  return useQuery<number>({
+    queryKey: [QUERY_KEYS.entries, 'count'],
+    queryFn: getEntryCount,
     enabled,
   });
 }

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -24,6 +24,7 @@ export const ar: Translations = {
   'Share Feedback': 'مشاركة الملاحظات',
   'Contact Us': 'اتصل بنا',
   'Unknown error': 'خطأ غير معروف',
+  Retry: 'إعادة المحاولة',
 
   // Header & Search
   'Search gratitude logs...': 'بحث في سجلات الامتنان...',

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -268,8 +268,6 @@ export const ar: Translations = {
   'Show Timeline Borders': 'إظهار حدود الجدول الزمني',
   'Show the borders in the timeline': 'إظهار الحدود في الجدول الزمني',
   'Hide the borders in the timeline': 'إخفاء الحدود من الجدول الزمني',
-  'Inspirational Quotes': 'اقتباسات ملهمة',
-  'Gratitude quotes will be shown on entry page': 'ستظهر اقتباسات الامتنان في صفحة السجل',
   'Date Style': 'نمط التاريخ',
   'Date includes day of the week': 'التاريخ يتضمن يوم الأسبوع',
   'First Day of Week': 'أول يوم في الأسبوع',
@@ -423,6 +421,8 @@ export const ar: Translations = {
   'Share Tackbok': 'شارك تاكبوك',
   'Share the app with friends and family':
     'هل تستمتع بتاكبوك؟ شارك التطبيق مع أصدقائك وعائلتك',
+  'Practice gratitude with Tackbok, a simple, free, and private gratitude journaling app':
+    'مارس الامتنان مع تاكبوك، تطبيق بسيط ومجاني وخاص لتدوين الامتنان',
   'Privacy Policy': 'سياسة الخصوصية',
   'Read our privacy policy': 'اقرأ سياسة خصوصية تاكبوك',
   'Terms & Conditions': 'الشروط والأحكام',
@@ -529,8 +529,7 @@ export const ar: Translations = {
   'Grateful for quiet streets, warm coffee, and a sky full of color.':
     'ممتن للشوارع الهادئة، والقهوة الدافئة، وسماء مليئة بالألوان.',
   'More themes…': 'مزيد من السمات…',
-  'What do you want to be more grateful for?':
-    'ما الذي تريد أن تكون أكثر امتنانًا له؟',
+  'What do you want to be more grateful for?': 'ما الذي تريد أن تكون أكثر امتنانًا له؟',
   'We’ll suggest writing prompts from the areas you pick.':
     'سنقترح عليك أفكارًا للكتابة من المجالات التي تختارها.',
   'Pick at least {count}': 'اختر {count} على الأقل',
@@ -591,8 +590,7 @@ export const ar: Translations = {
   sample_entry_welcome_body:
     'هذا دفتر امتنانك — مكان للحظات الجميلة. اضغط على زر + لكتابة سطر واحد أو صفحة كاملة، مرة في اليوم أو متى شئت. اضغط على هذه البطاقة لرؤية المدخل كاملًا.',
   sample_entry_photos_title: 'لحظات صغيرة',
-  sample_entry_photos_body:
-    'يمكنك إرفاق الصور بأي ذكرى — اضغط على صورة لتكبيرها.',
+  sample_entry_photos_body: 'يمكنك إرفاق الصور بأي ذكرى — اضغط على صورة لتكبيرها.',
   sample_entry_voice_title: 'بكلماتي الخاصة',
   sample_entry_voice_body:
     'أحيانًا يكون قولها أسهل. اضغط على التشغيل لسماع مذكّرة صوتية قصيرة.',

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -51,6 +51,7 @@ export const ar: Translations = {
   // Gratitude Entry
   'Delete Entry?': 'حذف السجل؟',
   'This entry will be permanently deleted.': 'سيتم حذف هذا السجل نهائيًا.',
+  'Entry not found': 'لم يتم العثور على المدخل',
   'Leave without saving?': 'المغادرة دون حفظ؟',
   'Your entry is unsaved. Would you like to keep editing or discard them?':
     'سجلك غير محفوظ. هل تريد الاستمرار في التحرير أو تجاهله؟',

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -463,6 +463,8 @@ export const ar: Translations = {
   'Next month': 'الشهر التالي',
   'Select month': 'اختر الشهر',
   'Select year': 'اختر السنة',
+  Random: 'عشوائي',
+  'Open a random entry': 'افتح مدخلًا عشوائيًا',
   Sun: 'أحد',
   Mon: 'إثنين',
   Tue: 'ثلاثاء',

--- a/apps/mobile/src/lib/i18n/translations/de.ts
+++ b/apps/mobile/src/lib/i18n/translations/de.ts
@@ -53,6 +53,7 @@ export const de: Translations = {
   // Gratitude Entry
   'Delete Entry?': 'Eintrag löschen?',
   'This entry will be permanently deleted.': 'Dieser Eintrag wird dauerhaft gelöscht.',
+  'Entry not found': 'Eintrag nicht gefunden',
   'Leave without saving?': 'Ohne Speichern verlassen?',
   'Your entry is unsaved. Would you like to keep editing or discard them?':
     'Dein Eintrag ist nicht gespeichert. Möchtest du ihn weiter bearbeiten oder verwerfen?',

--- a/apps/mobile/src/lib/i18n/translations/de.ts
+++ b/apps/mobile/src/lib/i18n/translations/de.ts
@@ -78,7 +78,8 @@ export const de: Translations = {
   'Please enable microphone access in your device settings to record voice memos.':
     'Aktiviere in den Geräteeinstellungen den Mikrofonzugriff, um Sprachnotizen aufzunehmen.',
   'Record Voice Note': 'Sprachnotiz aufnehmen',
-  'Tap the button below when ready.': 'Tippe auf die Schaltfläche unten, wenn du bereit bist.',
+  'Tap the button below when ready.':
+    'Tippe auf die Schaltfläche unten, wenn du bereit bist.',
   'Start Recording': 'Aufnahme starten',
   'Recording Voice Note...': 'Sprachnotiz wird aufgenommen …',
   'Stop Recording': 'Aufnahme beenden',
@@ -118,11 +119,13 @@ export const de: Translations = {
   'Create your first prompt': 'Erstelle deinen ersten Schreibimpuls',
 
   // Prompts - Faith
-  prompt_faith_1: 'Was ist deine früheste Erinnerung daran, Gottes Gegenwart gespürt zu haben?',
+  prompt_faith_1:
+    'Was ist deine früheste Erinnerung daran, Gottes Gegenwart gespürt zu haben?',
   prompt_faith_2: 'Wo hast du in letzter Zeit Gnade in deinem Leben erfahren?',
   prompt_faith_3: 'Welches Gebet hat dich durch eine schwere Zeit getragen?',
   prompt_faith_4: 'Wie hat dein Glaube deine Sicht auf Herausforderungen verändert?',
-  prompt_faith_5: 'Welche spirituelle Praxis oder Gewohnheit schenkt dir am meisten Frieden?',
+  prompt_faith_5:
+    'Welche spirituelle Praxis oder Gewohnheit schenkt dir am meisten Frieden?',
   prompt_faith_6:
     'Schreibe über einen Moment, in dem du dich eindeutig von einer höheren Macht geführt gefühlt hast.',
   prompt_faith_7:
@@ -155,14 +158,17 @@ export const de: Translations = {
   prompt_health_7: 'Was tust du heute für dein seelisches Wohlbefinden?',
   prompt_health_8:
     'Schreibe über eine Situation, in der du eine körperliche Herausforderung oder Verletzung überwunden hast.',
-  prompt_health_9: 'Mit welcher kleinen Änderung kannst du deine Schlafqualität verbessern?',
+  prompt_health_9:
+    'Mit welcher kleinen Änderung kannst du deine Schlafqualität verbessern?',
 
   // Prompts - Friends
-  prompt_friends_1: 'Welcher Freund oder welche Freundin hat dein Leben zuletzt leichter gemacht?',
+  prompt_friends_1:
+    'Welcher Freund oder welche Freundin hat dein Leben zuletzt leichter gemacht?',
   prompt_friends_2:
     'Welche Erinnerung mit einem Freund oder einer Freundin bringt dich noch immer zum Lächeln?',
   prompt_friends_3: 'Wem möchtest du diese Woche Mut machen?',
-  prompt_friends_4: 'Welche Eigenschaft schätzt du an deinen engsten Freundschaften am meisten?',
+  prompt_friends_4:
+    'Welche Eigenschaft schätzt du an deinen engsten Freundschaften am meisten?',
   prompt_friends_5:
     'Schreibe über jemanden, der dir geholfen hat, die Dinge aus einer anderen Perspektive zu betrachten.',
   prompt_friends_6:
@@ -176,7 +182,8 @@ export const de: Translations = {
   // Prompts - Family
   prompt_family_1: 'Für welche Familientradition bist du dankbar?',
   prompt_family_2: 'Wer in deiner Familie hat dir etwas Bleibendes beigebracht?',
-  prompt_family_3: 'An welchen kleinen Moment mit deiner Familie möchtest du dich erinnern?',
+  prompt_family_3:
+    'An welchen kleinen Moment mit deiner Familie möchtest du dich erinnern?',
   prompt_family_4: 'Welche Geschichte aus deiner Familie inspiriert dich?',
   prompt_family_5:
     'Wie hat sich deine Beziehung zu einem Familienmitglied im Laufe der Zeit entwickelt?',
@@ -184,7 +191,8 @@ export const de: Translations = {
     'Schreibe über eine Fähigkeit oder ein Rezept, das in deiner Familie weitergegeben wurde.',
   prompt_family_7:
     'Welche bestimmte Charaktereigenschaft teilst du mit einem Elternteil oder Geschwisterteil?',
-  prompt_family_8: 'Beschreibe eine Kindheitserinnerung, die dir noch immer große Freude bereitet.',
+  prompt_family_8:
+    'Beschreibe eine Kindheitserinnerung, die dir noch immer große Freude bereitet.',
   prompt_family_9: 'Wie unterstützt sich deine Familie in schwierigen Zeiten?',
 
   // Prompts - Little Things
@@ -199,8 +207,7 @@ export const de: Translations = {
   prompt_littleThings_7: 'Was war heute der schönste Teil deiner Morgenroutine?',
   prompt_littleThings_8:
     'Erzähle von einer kurzen Begegnung mit einer fremden Person, die dein Herz erwärmt hat.',
-  prompt_littleThings_9:
-    'Welcher günstige Gegenstand bereichert dein Leben besonders?',
+  prompt_littleThings_9: 'Welcher günstige Gegenstand bereichert dein Leben besonders?',
 
   // Default Worksheet Template Keys
   'What I am grateful for today...': 'Wofür ich heute dankbar bin …',
@@ -299,7 +306,8 @@ export const de: Translations = {
   // Settings - Typography
   Typography: 'Typografie',
   'Title Font': 'Titelschrift',
-  'Choose a font for titles and headings': 'Wähle eine Schriftart für Titel und Überschriften',
+  'Choose a font for titles and headings':
+    'Wähle eine Schriftart für Titel und Überschriften',
   Default: 'Standard',
   'Theme Default': 'Designstandard',
   'Font Size': 'Schriftgröße',
@@ -320,7 +328,8 @@ export const de: Translations = {
   'Start Writing': 'Losschreiben',
   'Journal Focus Areas': 'Themenschwerpunkte',
   'Personalize your journal prompts.': 'Personalisiere deine Schreibimpulse.',
-  'Pick the topics you want to write about.': 'Wähle die Themen aus, über die du schreiben möchtest.',
+  'Pick the topics you want to write about.':
+    'Wähle die Themen aus, über die du schreiben möchtest.',
   'Select at least 2 focus areas': 'Wähle mindestens 2 Themenschwerpunkte aus',
   'Journal Prompts': 'Schreibimpulse',
   'Choose which prompts to show when starting a new journal entry.':
@@ -365,7 +374,8 @@ export const de: Translations = {
   'All of your data in a format that you can restore in the app later':
     'Alle deine Daten in einem Format, das du später in der App wiederherstellen kannst',
   'Import as .ZIP': 'Als .ZIP importieren',
-  'Restore your data from a .zip file': 'Stelle deine Daten aus einer .zip-Datei wieder her',
+  'Restore your data from a .zip file':
+    'Stelle deine Daten aus einer .zip-Datei wieder her',
   'Import from Gratitude App': 'Aus der Gratitude App importieren',
   'Importing from Gratitude App': 'Import aus der Gratitude App',
   'Import data from a Gratitude App .zip backup':
@@ -492,6 +502,8 @@ export const de: Translations = {
   'Next month': 'Nächster Monat',
   'Select month': 'Monat auswählen',
   'Select year': 'Jahr auswählen',
+  Random: 'Zufällig',
+  'Open a random entry': 'Einen zufälligen Eintrag öffnen',
   Sun: 'So',
   Mon: 'Mo',
   Tue: 'Di',
@@ -537,8 +549,7 @@ export const de: Translations = {
   Next: 'Weiter',
   'Step {current} of {total}': 'Schritt {current} von {total}',
   'Get started': 'Loslegen',
-  'Already have a journal? Import it':
-    'Du hast bereits ein Tagebuch? Importiere es',
+  'Already have a journal? Import it': 'Du hast bereits ein Tagebuch? Importiere es',
   'A private place for your gratitude — free, offline, yours.':
     'Ein privater Ort für deine Dankbarkeit – kostenlos, offline und ganz für dich.',
   'Your journal stays on your device.': 'Dein Tagebuch bleibt auf deinem Gerät.',
@@ -559,8 +570,7 @@ export const de: Translations = {
   'Grateful for quiet streets, warm coffee, and a sky full of color.':
     'Dankbar für ruhige Straßen, warmen Kaffee und einen farbenfrohen Himmel.',
   'More themes…': 'Weitere Designs …',
-  'What do you want to be more grateful for?':
-    'Wofür möchtest du dankbarer sein?',
+  'What do you want to be more grateful for?': 'Wofür möchtest du dankbarer sein?',
   'We’ll suggest writing prompts from the areas you pick.':
     'Wir schlagen dir Schreibimpulse aus den ausgewählten Bereichen vor.',
   'Pick at least {count}': 'Wähle mindestens {count} aus',
@@ -601,8 +611,7 @@ export const de: Translations = {
   'Remove all': 'Alle entfernen',
   'Hide this banner': 'Diesen Hinweis ausblenden',
   'Example entries removed': 'Beispieleinträge entfernt',
-  'Failed to remove example entries':
-    'Beispieleinträge konnten nicht entfernt werden',
+  'Failed to remove example entries': 'Beispieleinträge konnten nicht entfernt werden',
   'Add today’s entry here.': 'Füge hier den heutigen Eintrag hinzu.',
   'Press and hold, then drag to move these buttons along the edge.':
     'Halte die Schaltflächen gedrückt und ziehe sie dann am Rand entlang, um sie zu verschieben.',

--- a/apps/mobile/src/lib/i18n/translations/de.ts
+++ b/apps/mobile/src/lib/i18n/translations/de.ts
@@ -290,9 +290,6 @@ export const de: Translations = {
   'Show Timeline Borders': 'Rahmen in der Zeitleiste anzeigen',
   'Show the borders in the timeline': 'Rahmen in der Zeitleiste anzeigen',
   'Hide the borders in the timeline': 'Rahmen in der Zeitleiste ausblenden',
-  'Inspirational Quotes': 'Inspirierende Zitate',
-  'Gratitude quotes will be shown on entry page':
-    'Dankbarkeitszitate werden auf der Eintragsseite angezeigt',
   'Date Style': 'Datumsformat',
   'Date includes day of the week': 'Datum enthält den Wochentag',
   'First Day of Week': 'Erster Wochentag',
@@ -452,6 +449,8 @@ export const de: Translations = {
   'Share Tackbok': 'Tackbok teilen',
   'Share the app with friends and family':
     'Gefällt dir Tackbok? Teile die App mit Freunden und Familie',
+  'Practice gratitude with Tackbok, a simple, free, and private gratitude journaling app':
+    'Übe Dankbarkeit mit Tackbok, einer einfachen, kostenlosen und privaten Dankbarkeitstagebuch-App',
   'Privacy Policy': 'Datenschutzerklärung',
   'Read our privacy policy': 'Datenschutzerklärung von Tackbok lesen',
   'Terms & Conditions': 'Allgemeine Geschäftsbedingungen',

--- a/apps/mobile/src/lib/i18n/translations/de.ts
+++ b/apps/mobile/src/lib/i18n/translations/de.ts
@@ -24,6 +24,7 @@ export const de: Translations = {
   'Share Feedback': 'Feedback teilen',
   'Contact Us': 'Kontakt',
   'Unknown error': 'Unbekannter Fehler',
+  Retry: 'Erneut versuchen',
 
   // Header & Search
   'Search gratitude logs...': 'Dankbarkeitseinträge durchsuchen …',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -478,6 +478,8 @@ export const en = {
   'Next month': 'Next month',
   'Select month': 'Select month',
   'Select year': 'Select year',
+  Random: 'Random',
+  'Open a random entry': 'Open a random entry',
   Sun: 'Sun',
   Mon: 'Mon',
   Tue: 'Tue',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -281,9 +281,6 @@ export const en = {
   'Show Timeline Borders': 'Show Timeline Borders',
   'Show the borders in the timeline': 'Show the borders in the timeline',
   'Hide the borders in the timeline': 'Hide the borders in the timeline',
-  'Inspirational Quotes': 'Inspirational Quotes',
-  'Gratitude quotes will be shown on entry page':
-    'Gratitude quotes will be shown on entry page',
   'Date Style': 'Date Style',
   'Date includes day of the week': 'Date includes day of the week',
   'First Day of Week': 'First Day of Week',
@@ -439,6 +436,8 @@ export const en = {
   'Share Tackbok': 'Share Tackbok',
   'Share the app with friends and family':
     'Enjoying Tackbok? Share the app with your friends and family',
+  'Practice gratitude with Tackbok, a simple, free, and private gratitude journaling app':
+    'Practice gratitude with Tackbok, a simple, free, and private gratitude journaling app',
   'Privacy Policy': 'Privacy Policy',
   'Read our privacy policy': "Read Tackbok's privacy policy",
   'Terms & Conditions': 'Terms & Conditions',
@@ -607,8 +606,7 @@ export const en = {
   sample_entry_welcome_body:
     'This is your gratitude journal — a place for the good moments. Tap the + button to write one line or a whole page, once a day or whenever you like. Tap this card to see the full entry.',
   sample_entry_photos_title: 'Small moments',
-  sample_entry_photos_body:
-    'You can attach photos to a memory — tap one to zoom.',
+  sample_entry_photos_body: 'You can attach photos to a memory — tap one to zoom.',
   sample_entry_voice_title: 'In my own words',
   sample_entry_voice_body:
     'Sometimes it’s easier to say it out loud. Tap play to hear a short voice memo.',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -52,6 +52,7 @@ export const en = {
   // Gratitude Entry
   'Delete Entry?': 'Delete Entry?',
   'This entry will be permanently deleted.': 'This entry will be permanently deleted.',
+  'Entry not found': 'Entry not found',
   'Leave without saving?': 'Leave without saving?',
   'Your entry is unsaved. Would you like to keep editing or discard them?':
     'Your entry is unsaved. Would you like to keep editing or discard them?',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -23,6 +23,7 @@ export const en = {
   'Share Feedback': 'Share Feedback',
   'Contact Us': 'Contact Us',
   'Unknown error': 'Unknown error',
+  Retry: 'Retry',
 
   // Header & Search
   'Search gratitude logs...': 'Search gratitude logs...',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -269,8 +269,6 @@ export const he: Translations = {
   'Show Timeline Borders': 'הצג גבולות ציר זמן',
   'Show the borders in the timeline': 'הצג את הגבולות בציר הזמן',
   'Hide the borders in the timeline': 'הסתר את הגבולות בציר הזמן',
-  'Inspirational Quotes': 'ציטוטים מעוררי השראה',
-  'Gratitude quotes will be shown on entry page': 'ציטוטי הכרת טובה יוצגו בדף הרשומה',
   'Date Style': 'סגנון תאריך',
   'Date includes day of the week': 'התאריך כולל את יום השבוע',
   'First Day of Week': 'היום הראשון בשבוע',
@@ -422,6 +420,8 @@ export const he: Translations = {
   'Share Tackbok': 'שתף את טאקבוק',
   'Share the app with friends and family':
     'נהנה מטאקבוק? שתף את האפליקציה עם חברים ומשפחה',
+  'Practice gratitude with Tackbok, a simple, free, and private gratitude journaling app':
+    'תרגל הכרת תודה עם טאקבוק, אפליקציה פשוטה, חינמית ופרטית ליומן תודה',
   'Privacy Policy': 'מדיניות פרטיות',
   'Read our privacy policy': 'קרא את מדיניות הפרטיות של טאקבוק',
   'Terms & Conditions': 'תנאים והגבלות',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -52,6 +52,7 @@ export const he: Translations = {
   // Gratitude Entry
   'Delete Entry?': 'מחק רשומה?',
   'This entry will be permanently deleted.': 'רשומה זו תימחק לצמיתות.',
+  'Entry not found': 'הרשומה לא נמצאה',
   'Leave without saving?': 'לצאת ללא שמירה?',
   'Your entry is unsaved. Would you like to keep editing or discard them?':
     'הרשומה לא נשמרה. האם ברצונך להמשיך לערוך או למחוק?',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -462,6 +462,8 @@ export const he: Translations = {
   'Next month': 'החודש הבא',
   'Select month': 'בחר חודש',
   'Select year': 'בחר שנה',
+  Random: 'אקראי',
+  'Open a random entry': 'פתח רשומה אקראית',
   Sun: 'א',
   Mon: 'ב',
   Tue: 'ג',
@@ -528,8 +530,7 @@ export const he: Translations = {
   'Grateful for quiet streets, warm coffee, and a sky full of color.':
     'תודה על רחובות שקטים, קפה חם ושמיים מלאי צבע.',
   'More themes…': 'עוד ערכות נושא…',
-  'What do you want to be more grateful for?':
-    'על מה תרצו להכיר תודה יותר?',
+  'What do you want to be more grateful for?': 'על מה תרצו להכיר תודה יותר?',
   'We’ll suggest writing prompts from the areas you pick.':
     'נציע לכם רעיונות לכתיבה מהתחומים שתבחרו.',
   'Pick at least {count}': 'בחרו לפחות {count}',
@@ -590,8 +591,7 @@ export const he: Translations = {
   sample_entry_welcome_body:
     'זהו יומן הכרת התודה שלכם — מקום לרגעים הטובים. הקישו על כפתור + כדי לכתוב שורה אחת או עמוד שלם, פעם ביום או מתי שתרצו. הקישו על הכרטיס הזה כדי לראות את הרשומה המלאה.',
   sample_entry_photos_title: 'רגעים קטנים',
-  sample_entry_photos_body:
-    'אפשר לצרף תמונות לזיכרון — הקישו על תמונה כדי להגדיל.',
+  sample_entry_photos_body: 'אפשר לצרף תמונות לזיכרון — הקישו על תמונה כדי להגדיל.',
   sample_entry_voice_title: 'במילים שלי',
   sample_entry_voice_body:
     'לפעמים קל יותר לומר את זה בקול. הקישו על נגן כדי לשמוע הקלטה קצרה.',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -24,6 +24,7 @@ export const he: Translations = {
   'Share Feedback': 'שתף משוב',
   'Contact Us': 'צור קשר',
   'Unknown error': 'שגיאה לא ידועה',
+  Retry: 'נסה שוב',
 
   // Header & Search
   'Search gratitude logs...': 'חפש יומני הכרת טובה...',

--- a/apps/mobile/src/lib/i18n/translations/translations.test.ts
+++ b/apps/mobile/src/lib/i18n/translations/translations.test.ts
@@ -32,7 +32,7 @@ function collectSourceFiles(dir: string): string[] {
 /**
  * Extracts dynamic key prefixes from source code that are used in template
  * literal string translations.
- * 
+ *
  * Example prefixes detected by the regex /\`([a-zA-Z_][\\w. ]*[_ ])\\$\\{/g:
  * - "Feeling " (from \`Feeling ${status}\`)
  * - "TackbokBackup_" (from \`TackbokBackup_${type}\`)
@@ -94,9 +94,7 @@ describe('Translations', () => {
 
   test('languages are listed alphabetically by display name', () => {
     const displayNames = languages.map(({ displayName }) => displayName);
-    const sortedDisplayNames = [...displayNames].sort((a, b) =>
-      a.localeCompare(b, 'en'),
-    );
+    const sortedDisplayNames = [...displayNames].sort((a, b) => a.localeCompare(b, 'en'));
 
     expect(displayNames).toEqual(sortedDisplayNames);
   });

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -450,6 +450,8 @@ export const zhCN: Translations = {
   'Next month': '下个月',
   'Select month': '选择月份',
   'Select year': '选择年份',
+  Random: '随机',
+  'Open a random entry': '打开一个随机条目',
   Sun: '周日',
   Mon: '周一',
   Tue: '周二',
@@ -579,8 +581,7 @@ export const zhCN: Translations = {
   sample_entry_photos_title: '小小瞬间',
   sample_entry_photos_body: '你可以为回忆附上照片 — 点按图片即可放大。',
   sample_entry_voice_title: '用我自己的声音',
-  sample_entry_voice_body:
-    '有时说出来更容易。点按播放，听一段简短的语音备忘。',
+  sample_entry_voice_body: '有时说出来更容易。点按播放，听一段简短的语音备忘。',
   sample_entry_tags_body:
     '这条日记回答了一条写作灵感，并带有两个标签。试试顶部的搜索，按标签筛选就能再次找到它。',
 

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -51,6 +51,7 @@ export const zhCN: Translations = {
   // Gratitude Entry
   'Delete Entry?': '删除条目？',
   'This entry will be permanently deleted.': '此条目将被永久删除。',
+  'Entry not found': '未找到条目',
   'Leave without saving?': '不保存离开？',
   'Your entry is unsaved. Would you like to keep editing or discard them?':
     '您的条目未保存。您想继续编辑还是丢弃？',

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -24,6 +24,7 @@ export const zhCN: Translations = {
   'Share Feedback': '分享反馈',
   'Contact Us': '联系我们',
   'Unknown error': '未知错误',
+  Retry: '重试',
 
   // Header & Search
   'Search gratitude logs...': '搜索感恩日志...',

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -263,8 +263,6 @@ export const zhCN: Translations = {
   'Show Timeline Borders': '显示时间线边框',
   'Show the borders in the timeline': '显示时间线中的边框',
   'Hide the borders in the timeline': '隐藏时间线中的边框',
-  'Inspirational Quotes': '励志名言',
-  'Gratitude quotes will be shown on entry page': '感恩名言将在条目页面显示',
   'Date Style': '日期样式',
   'Date includes day of the week': '日期包含星期几',
   'First Day of Week': '一周的第一天',
@@ -410,6 +408,8 @@ export const zhCN: Translations = {
   'Read frequently asked questions': '阅读塔克博克的常见问题',
   'Share Tackbok': '分享塔克博克',
   'Share the app with friends and family': '喜欢塔克博克吗？与您的朋友和家人分享这个应用',
+  'Practice gratitude with Tackbok, a simple, free, and private gratitude journaling app':
+    '用塔克博克练习感恩，一款简单、免费且私密的感恩日记应用',
   'Privacy Policy': '隐私政策',
   'Read our privacy policy': '阅读塔克博克的隐私政策',
   'Terms & Conditions': '条款和条件',

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -452,6 +452,8 @@ export const zhTW: Translations = {
   'Next month': '下個月',
   'Select month': '選擇月份',
   'Select year': '選擇年份',
+  Random: '隨機',
+  'Open a random entry': '開啟隨機紀錄',
   Sun: '週日',
   Mon: '週一',
   Tue: '週二',
@@ -581,8 +583,7 @@ export const zhTW: Translations = {
   sample_entry_photos_title: '小小瞬間',
   sample_entry_photos_body: '你可以為回憶附上照片 — 點一下圖片即可放大。',
   sample_entry_voice_title: '用我自己的聲音',
-  sample_entry_voice_body:
-    '有時說出來更容易。點一下播放，聽一段簡短的語音備忘。',
+  sample_entry_voice_body: '有時說出來更容易。點一下播放，聽一段簡短的語音備忘。',
   sample_entry_tags_body:
     '這則日記回答了一條書寫靈感，並帶有兩個標籤。試試頂部的搜尋，依標籤篩選就能再次找到它。',
 

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -264,8 +264,6 @@ export const zhTW: Translations = {
   'Show Timeline Borders': '顯示時間軸邊框',
   'Show the borders in the timeline': '顯示時間軸中的邊框',
   'Hide the borders in the timeline': '隱藏時間軸中的邊框',
-  'Inspirational Quotes': '勵志名言',
-  'Gratitude quotes will be shown on entry page': '感恩名言將顯示於紀錄頁面',
   'Date Style': '日期樣式',
   'Date includes day of the week': '日期包含星期',
   'First Day of Week': '每週的第一天',
@@ -412,6 +410,8 @@ export const zhTW: Translations = {
   'Read frequently asked questions': '閱讀塔克博克的常見問題',
   'Share Tackbok': '分享塔克博克',
   'Share the app with friends and family': '喜歡塔克博克嗎？與您的親友分享此應用程式',
+  'Practice gratitude with Tackbok, a simple, free, and private gratitude journaling app':
+    '用塔克博克練習感恩，一款簡單、免費且私密的感恩日記應用程式',
   'Privacy Policy': '隱私權政策',
   'Read our privacy policy': '閱讀塔克博克的隱私權政策',
   'Terms & Conditions': '條款與條件',

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -51,6 +51,7 @@ export const zhTW: Translations = {
   // Gratitude Entry
   'Delete Entry?': '刪除紀錄？',
   'This entry will be permanently deleted.': '此紀錄將被永久刪除。',
+  'Entry not found': '找不到紀錄',
   'Leave without saving?': '離開而不儲存？',
   'Your entry is unsaved. Would you like to keep editing or discard them?':
     '您的紀錄尚未儲存。您想繼續編輯還是捨棄？',

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -24,6 +24,7 @@ export const zhTW: Translations = {
   'Share Feedback': '分享意見',
   'Contact Us': '聯絡我們',
   'Unknown error': '未知錯誤',
+  Retry: '重試',
 
   // Header & Search
   'Search gratitude logs...': '搜尋感恩日誌...',

--- a/apps/mobile/src/lib/settings/store.ts
+++ b/apps/mobile/src/lib/settings/store.ts
@@ -35,7 +35,6 @@ interface SettingsState {
   // Appearance
   theme: string;
   timelineEntryLength: number; // 1-50, default 10
-  inspirationalQuotesEnabled: boolean;
   dateIncludesDayOfWeek: boolean;
   firstDayOfWeek: FirstDayOfWeek;
   showTimelineBorders: boolean;
@@ -85,7 +84,6 @@ interface SettingsState {
   setProfileImageUri: (uri: string | null) => void;
   setTheme: (theme: string) => void;
   setTimelineEntryLength: (length: number) => void;
-  setInspirationalQuotesEnabled: (enabled: boolean) => void;
   setDateIncludesDayOfWeek: (enabled: boolean) => void;
   setFirstDayOfWeek: (day: FirstDayOfWeek) => void;
   setShowTimelineBorders: (enabled: boolean) => void;
@@ -117,7 +115,6 @@ const DEFAULT_SETTINGS_VALUES = {
   profileImageUri: null,
   theme: DEFAULT_THEME_ID,
   timelineEntryLength: 10,
-  inspirationalQuotesEnabled: true,
   dateIncludesDayOfWeek: false,
   firstDayOfWeek: FirstDay.MONDAY,
   showTimelineBorders: false,
@@ -163,8 +160,6 @@ export const useSettingsStore = create<SettingsState>()(
         const safeLength = Math.max(1, Math.min(50, length));
         set({ timelineEntryLength: safeLength });
       },
-      setInspirationalQuotesEnabled: (enabled) =>
-        set({ inspirationalQuotesEnabled: enabled }),
       setDateIncludesDayOfWeek: (enabled) => set({ dateIncludesDayOfWeek: enabled }),
       setFirstDayOfWeek: (day) => set({ firstDayOfWeek: day }),
       setShowTimelineBorders: (enabled) => set({ showTimelineBorders: enabled }),
@@ -237,7 +232,6 @@ export const useSettingsStore = create<SettingsState>()(
         profileImageUri: state.profileImageUri,
         theme: state.theme,
         timelineEntryLength: state.timelineEntryLength,
-        inspirationalQuotesEnabled: state.inspirationalQuotesEnabled,
         dateIncludesDayOfWeek: state.dateIncludesDayOfWeek,
         firstDayOfWeek: state.firstDayOfWeek,
         showTimelineBorders: state.showTimelineBorders,

--- a/apps/mobile/src/screens/gratitudeEntry/index.tsx
+++ b/apps/mobile/src/screens/gratitudeEntry/index.tsx
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { View, ActivityIndicator } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useEntry } from '~/hooks/useGratitude';
+import { useTranslation } from '~/lib/i18n';
 import type { Asset } from '~/types';
 import { SafeAreaView } from '~/components/ui/safe-area-view';
+import { Button } from '~/components/ui/button';
+import { Text } from '~/components/ui/text';
 import { ImageViewerModal } from '~/components/ImageViewerModal';
 import { ThemeBackdrop } from '~/components/backdrops/ThemeBackdrop';
 import { GratitudeEntryView } from './GratitudeEntryView';
@@ -22,7 +25,14 @@ export default function GratitudeEntryScreen({
 }: IGratitudeEntryProps) {
   const [isEditMode, setIsEditMode] = useState(!noteId);
   const router = useRouter();
-  const { data: entry } = useEntry(noteId);
+  const { t } = useTranslation();
+  const { data: entry, isLoading } = useEntry(noteId);
+
+  // Deleting an entry clears its cache before the delayed back-navigation runs,
+  // so keep the last loaded entry on screen instead of flashing "not found".
+  const lastEntryRef = useRef(entry);
+  if (entry) lastEntryRef.current = entry;
+  const displayEntry = entry ?? lastEntryRef.current;
 
   // Image Viewer — single instance shared by both View and Edit modes
   const [viewerPhotos, setViewerPhotos] = useState<Asset[]>([]);
@@ -63,16 +73,28 @@ export default function GratitudeEntryScreen({
           }}
           onPhotoPress={handlePhotoPress}
         />
-      ) : !entry && noteId ? (
-        <View className="flex-1 items-center justify-center">
-          {/* Native loading indicator */}
-          <ActivityIndicator size="large" />
-        </View>
+      ) : !displayEntry && noteId ? (
+        isLoading ? (
+          <View className="flex-1 items-center justify-center">
+            {/* Native loading indicator */}
+            <ActivityIndicator size="large" />
+          </View>
+        ) : (
+          /* Query settled without a result — the entry no longer exists */
+          <View className="flex-1 items-center justify-center gap-4 px-8">
+            <Text className="text-lg font-body-medium text-muted-foreground">
+              {t('Entry not found')}
+            </Text>
+            <Button variant="outline" onPress={() => router.back()}>
+              <Text>{t('Back')}</Text>
+            </Button>
+          </View>
+        )
       ) : (
         /* View Mode */
-        entry && (
+        displayEntry && (
           <GratitudeEntryView
-            entry={entry}
+            entry={displayEntry}
             onEdit={() => setIsEditMode(true)}
             onBack={() => router.back()}
             onPhotoPress={handlePhotoPress}

--- a/apps/mobile/src/screens/gratitudeEntry/index.tsx
+++ b/apps/mobile/src/screens/gratitudeEntry/index.tsx
@@ -26,13 +26,16 @@ export default function GratitudeEntryScreen({
   const [isEditMode, setIsEditMode] = useState(!noteId);
   const router = useRouter();
   const { t } = useTranslation();
-  const { data: entry, isLoading } = useEntry(noteId);
+  const { data: entry, isLoading, isError, refetch } = useEntry(noteId);
 
   // Deleting an entry clears its cache before the delayed back-navigation runs,
   // so keep the last loaded entry on screen instead of flashing "not found".
-  const lastEntryRef = useRef(entry);
-  if (entry) lastEntryRef.current = entry;
-  const displayEntry = entry ?? lastEntryRef.current;
+  // Scoped to noteId so a reused screen never falls back to a different entry.
+  const lastEntryRef = useRef({ noteId, entry });
+  if (entry) lastEntryRef.current = { noteId, entry };
+  const displayEntry =
+    entry ??
+    (lastEntryRef.current.noteId === noteId ? lastEntryRef.current.entry : undefined);
 
   // Image Viewer — single instance shared by both View and Edit modes
   const [viewerPhotos, setViewerPhotos] = useState<Asset[]>([]);
@@ -78,6 +81,19 @@ export default function GratitudeEntryScreen({
           <View className="flex-1 items-center justify-center">
             {/* Native loading indicator */}
             <ActivityIndicator size="large" />
+          </View>
+        ) : isError ? (
+          /* Query failed (e.g. transient db error) — the entry may still exist */
+          <View className="flex-1 items-center justify-center gap-4 px-8">
+            <Text className="text-lg font-body-medium text-muted-foreground">
+              {t('Unknown error')}
+            </Text>
+            <Button onPress={() => refetch()}>
+              <Text>{t('Retry')}</Text>
+            </Button>
+            <Button variant="outline" onPress={() => router.back()}>
+              <Text>{t('Back')}</Text>
+            </Button>
           </View>
         ) : (
           /* Query settled without a result — the entry no longer exists */

--- a/apps/mobile/src/screens/home/GratitudeTimelineItem.tsx
+++ b/apps/mobile/src/screens/home/GratitudeTimelineItem.tsx
@@ -238,6 +238,9 @@ export const TimelineItem: React.FC<ITimelineItemProps> = ({
   const { t, isRTL } = useTranslation();
   const timelineEntryLength = useSettingsStore((state) => state.timelineEntryLength);
   const showTimelineBorders = useSettingsStore((state) => state.showTimelineBorders);
+  const dateIncludesDayOfWeek = useSettingsStore(
+    (state) => state.dateIncludesDayOfWeek,
+  );
   const tagMap = useTagMapping();
   const animatedButtonRef = useRef<AnimatedButtonHandle>(null);
 
@@ -254,7 +257,9 @@ export const TimelineItem: React.FC<ITimelineItemProps> = ({
 
   const isExpanded = isExpandedProp ?? dayGroup.isExpanded;
 
-  const formattedDate = formatLocalizedDate(dayGroup.dateStr, t);
+  const formattedDate = formatLocalizedDate(dayGroup.dateStr, t, {
+    includeWeekday: dateIncludesDayOfWeek,
+  });
   const isToday = dayGroup.isToday ?? false;
   const hasEntries = dayGroup.entries.length > 0;
   const hasVoiceMemos = dayGroup.entries.some(

--- a/apps/mobile/src/screens/home/index.tsx
+++ b/apps/mobile/src/screens/home/index.tsx
@@ -71,12 +71,15 @@ export default function HomeScreen() {
   const handleRandomEntryPress = useCallback(async () => {
     try {
       const noteId = await getRandomEntryId();
-      if (noteId) {
-        router.push({
-          pathname: '/gratitudeEntry/[noteId]',
-          params: { noteId },
-        });
+      // The button can outlive the last entry via a stale cached count
+      if (!noteId) {
+        toast.error(t('Unknown error'));
+        return;
       }
+      router.push({
+        pathname: '/gratitudeEntry/[noteId]',
+        params: { noteId },
+      });
     } catch (error) {
       console.error('Failed to open a random entry:', error);
       toast.error(t('Unknown error'));

--- a/apps/mobile/src/screens/home/index.tsx
+++ b/apps/mobile/src/screens/home/index.tsx
@@ -4,7 +4,7 @@ import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { startOfDay } from 'date-fns';
 import { useRouter } from 'expo-router';
 import { type Entry } from '~/types';
-import { getEntriesForDay } from '~/db/queries';
+import { getEntriesForDay, getRandomEntryId } from '~/db/queries';
 import { combineDateWithCurrentTime } from '~/lib/utils';
 import { useTranslation } from '~/lib/i18n';
 import { useGratitudeActionDockScrollBehavior } from '~/hooks/useGratitudeActionDockScrollBehavior';
@@ -68,6 +68,21 @@ export default function HomeScreen() {
     [router, t],
   );
 
+  const handleRandomEntryPress = useCallback(async () => {
+    try {
+      const noteId = await getRandomEntryId();
+      if (noteId) {
+        router.push({
+          pathname: '/gratitudeEntry/[noteId]',
+          params: { noteId },
+        });
+      }
+    } catch (error) {
+      console.error('Failed to open a random entry:', error);
+      toast.error(t('Unknown error'));
+    }
+  }, [router, t]);
+
   const handleSearchPress = () => {
     setIsSearchMode(true);
     setSearchQuery('');
@@ -108,9 +123,7 @@ export default function HomeScreen() {
   }, [router]);
 
   return (
-    <SafeAreaView
-      className="flex-1 w-full bg-primary"
-      edges={['top', 'left', 'right']}>
+    <SafeAreaView className="flex-1 w-full bg-primary" edges={['top', 'left', 'right']}>
       <Header
         isSearchMode={isSearchMode}
         onSearchPress={handleSearchPress}
@@ -152,6 +165,7 @@ export default function HomeScreen() {
             visible={showDatePicker}
             onClose={() => setShowDatePicker(false)}
             onDateSelect={handleGratitudeDatepickerPress}
+            onRandomSelect={handleRandomEntryPress}
           />
         </View>
       )}

--- a/apps/mobile/src/screens/settings/sections/AppInfoSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/AppInfoSection.tsx
@@ -112,6 +112,7 @@ export function AppInfoSection() {
       );
     } catch (error) {
       console.warn('Failed to open the share sheet:', error);
+      toast.error(t('Unknown error'));
     }
   };
 

--- a/apps/mobile/src/screens/settings/sections/AppInfoSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/AppInfoSection.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { View, Linking } from 'react-native';
+import { View, Linking, Share, Platform } from 'react-native';
 import { useRouter } from 'expo-router';
 import Constants from 'expo-constants';
 import * as Application from 'expo-application';
@@ -98,6 +98,23 @@ export function AppInfoSection() {
     }
   };
 
+  const handleShare = async () => {
+    try {
+      const message = t(
+        'Practice gratitude with Tackbok, a simple, free, and private gratitude journaling app',
+      );
+      // iOS renders rich link previews only for the dedicated url field;
+      // Android ignores it, so the link must stay in the message there.
+      await Share.share(
+        Platform.OS === 'ios'
+          ? { message, url: 'https://tackbok.org' }
+          : { message: `${message}\nhttps://tackbok.org` },
+      );
+    } catch (error) {
+      console.warn('Failed to open the share sheet:', error);
+    }
+  };
+
   const handleReplayOnboarding = () => {
     setShowReplayOnboardingDialog(false);
     const settings = useSettingsStore.getState();
@@ -113,9 +130,7 @@ export function AppInfoSection() {
         label={t('Share Tackbok')}
         description={t('Share the app with friends and family')}
         icon={Share2}
-        onPress={() => {
-          // TODO: Implement share functionality
-        }}
+        onPress={handleShare}
         showChevron
       />
       <SettingsRow
@@ -170,11 +185,7 @@ export function AppInfoSection() {
           onPress={handleRestart}
         />
       )}
-      <SettingsRow
-        label={t('Version')}
-        description={displayedVersion}
-        icon={Info}
-      />
+      <SettingsRow label={t('Version')} description={displayedVersion} icon={Info} />
       <SettingsRow
         label={t('Replay Onboarding')}
         description={t('Run the welcome setup again')}

--- a/apps/mobile/src/screens/settings/sections/AppearanceSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/AppearanceSection.tsx
@@ -3,7 +3,6 @@ import { View } from 'react-native';
 import {
   Palette,
   AlignLeft,
-  Quote,
   Calendar,
   CalendarDays,
   Table2,
@@ -26,8 +25,6 @@ export function AppearanceSection() {
   const {
     timelineEntryLength,
     setTimelineEntryLength,
-    inspirationalQuotesEnabled,
-    setInspirationalQuotesEnabled,
     showTimelineBorders,
     setShowTimelineBorders,
     dateIncludesDayOfWeek,
@@ -97,17 +94,6 @@ export function AppearanceSection() {
             </View>
           </View>
         </View>
-        <SettingsRow
-          label={t('Inspirational Quotes')}
-          description={t('Gratitude quotes will be shown on entry page')}
-          icon={Quote}
-          onPress={() => setInspirationalQuotesEnabled(!inspirationalQuotesEnabled)}
-          rightElement={
-            <View pointerEvents="none">
-              <Switch checked={inspirationalQuotesEnabled} />
-            </View>
-          }
-        />
         <SettingsRow
           label={t('Date Style')}
           description={t('Date includes day of the week')}

--- a/apps/website/src/pages/faq.astro
+++ b/apps/website/src/pages/faq.astro
@@ -81,10 +81,6 @@ const faqs = [
     <section
       class="overflow-hidden border-b border-line bg-[radial-gradient(circle_at_85%_20%,rgba(140,159,111,0.28),transparent_23rem),radial-gradient(circle_at_5%_95%,rgba(227,205,151,0.26),transparent_22rem),var(--paper)] py-[clamp(5rem,10vw,8rem)]">
       <div class="mx-auto w-full max-w-[820px] px-6 text-center sm:px-8">
-        <p
-          class="mb-4 text-[0.76rem] font-extrabold tracking-[0.16em] text-sage uppercase">
-          Questions are welcome here
-        </p>
         <h1
           class="mx-auto mb-5 text-[clamp(3rem,7vw,5.7rem)] leading-[1.03] font-[690] tracking-[-0.055em]">
           Frequently asked questions.


### PR DESCRIPTION
- implement the "Share Tackbok" settings row via the native share sheet with a localized message
- apply the "Date includes day of the week" setting to timeline date headers
- remove the unused Inspirational Quotes setting, its store state, and translations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Random” to open a random gratitude entry (including the date picker).
  * Added native “Share Tackbok” from App Info.
* **Improvements**
  * Timeline date formatting can now include the day of the week.
  * Improved “Entry not found” handling to avoid brief flashes during navigation.
  * Updated translated onboarding/marketing text.
* **Changes**
  * Removed the Inspirational Quotes setting.
* **Documentation**
  * Simplified the FAQ hero text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->