### PR TITLE
perf: speed up zip I/O paths and harden the DEFLATE codec

### DIFF
--- a/apps/mobile/jest.global-setup.js
+++ b/apps/mobile/jest.global-setup.js
@@ -1,0 +1,14 @@
+/**
+ * Runs once in the Jest parent process before any test workers spawn, so the
+ * env var below is inherited by every worker (and by --runInBand runs).
+ *
+ * EXPO_PUBLIC_USE_RN_FETCH=1 stops Expo's winter runtime from installing its
+ * lazy `fetch` getter on globalThis (see expo/src/winter/runtime.native.ts).
+ * In Jest that getter fires during teardown, tries to require the
+ * ExpoFetchModule native module, and fails — producing "Cannot log after
+ * tests are done" warnings and intermittently poisoning Jest's exit code
+ * even when every test passes.
+ */
+module.exports = function globalSetup() {
+  process.env.EXPO_PUBLIC_USE_RN_FETCH = '1';
+};

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -99,6 +99,7 @@
   },
   "jest": {
     "preset": "jest-expo",
+    "globalSetup": "<rootDir>/jest.global-setup.js",
     "transformIgnorePatterns": [
       "node_modules/(?!.*((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg))"
     ]

--- a/apps/mobile/src/lib/backupImport/portable.ts
+++ b/apps/mobile/src/lib/backupImport/portable.ts
@@ -83,6 +83,14 @@ interface MaterializedPortableAssetsResult {
   hadFailures: boolean;
 }
 
+/**
+ * Lets the UI thread render between synchronous asset reads/writes; a plain
+ * await only yields a microtask, which never frees a frame.
+ */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 async function materializePortableEntryAssets(
   portableEntry: PortableEntry,
   zip: ZipReader,
@@ -94,6 +102,7 @@ async function materializePortableEntryAssets(
   let hadFailures = false;
 
   for (const portableAsset of portableEntry.assets ?? []) {
+    await yieldToEventLoop();
     try {
       const archivePath = assertSafeArchivePath(portableAsset.path);
       const bytes = await readSafeZipBytes(zip, archivePath);

--- a/apps/mobile/src/lib/zip/README.md
+++ b/apps/mobile/src/lib/zip/README.md
@@ -208,6 +208,11 @@ These are the APIs to prefer for real backup import/export flows because they av
 
 These are still useful for tests, fixtures, tiny archives, and cases where the ZIP already exists as a `Uint8Array`.
 
+They are deliberately **not** exported from the top-level `~/lib/zip` facade, so app code cannot grow accidental dependencies on them. Import them directly from their modules instead:
+
+- `~/lib/zip/reader/memory-reader`
+- `~/lib/zip/writer/memory-writer`
+
 Ownership is explicit by layer:
 
 - in-memory reader helpers live under `reader/memory-reader`
@@ -370,7 +375,7 @@ Why use this path:
 ### Build a small ZIP in memory
 
 ```ts
-import { createMemoryZipWriter } from '~/lib/zip';
+import { createMemoryZipWriter } from '~/lib/zip/writer/memory-writer';
 
 const zip = createMemoryZipWriter();
 zip.addText('manifest.json', JSON.stringify({ ok: true }));
@@ -388,7 +393,11 @@ Why use this path:
 ### Parse a small ZIP already loaded into memory
 
 ```ts
-import { parseZipArchive, readZipEntryJson, readZipEntryText } from '~/lib/zip';
+import {
+  parseZipArchive,
+  readZipEntryJson,
+  readZipEntryText,
+} from '~/lib/zip/reader/memory-reader';
 
 const archive = parseZipArchive(zipBytes);
 const manifest = readZipEntryJson<{ ok: boolean }>(archive, 'manifest.json');
@@ -412,6 +421,6 @@ Use `parseZipArchive` when you already have ZIP bytes in memory and the archive 
 
 ## Design Notes
 
-- The top-level facade favors the scalable path, but still exposes explicit in-memory helpers.
+- The top-level facade exposes only the scalable path; the explicit in-memory helpers are imported from their own modules (tests and fixtures only).
 - `core/` is intentionally platform-agnostic so it can be extracted later without Expo code.
 - `adapters/expo/` is intentionally thin so file-backed behavior stays outside the pure ZIP logic.

--- a/apps/mobile/src/lib/zip/adapters/expo/file-bytes.ts
+++ b/apps/mobile/src/lib/zip/adapters/expo/file-bytes.ts
@@ -10,27 +10,3 @@ function resolveFile(fileOrUri: File | string): File {
 export function getFileByteSize(fileOrUri: File | string): number {
 	return resolveFile(fileOrUri).size;
 }
-
-/**
- * Reads an exact byte range from an Expo file.
- */
-export function readFileBytesRange(
-	fileOrUri: File | string,
-	offset: number,
-	length: number,
-): Uint8Array {
-	const file = resolveFile(fileOrUri);
-	const end = offset + length;
-
-	if (offset < 0 || length < 0 || end > file.size) {
-		throw new Error('Requested byte range is outside the file');
-	}
-
-	const handle = file.open();
-	try {
-		handle.offset = offset;
-		return handle.readBytes(length);
-	} finally {
-		handle.close();
-	}
-}

--- a/apps/mobile/src/lib/zip/adapters/expo/file-zip-writer.ts
+++ b/apps/mobile/src/lib/zip/adapters/expo/file-zip-writer.ts
@@ -4,9 +4,20 @@ import {
   type ZipWriter,
   type ZipChunkSource,
 } from '../../writer/sequential-writer';
-import { getFileByteSize, readFileBytesRange } from './file-bytes';
+import { getFileByteSize } from './file-bytes';
 
-const DEFAULT_CHUNK_SIZE = 256 * 1024;
+const DEFAULT_CHUNK_SIZE = 1024 * 1024;
+
+/**
+ * How many bytes to stream between yields back to the event loop. Expo file
+ * reads/writes are synchronous, so without a real macrotask yield the JS
+ * thread (and therefore the UI) is frozen for the whole export.
+ */
+const YIELD_INTERVAL_BYTES = 4 * 1024 * 1024;
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 /**
  * File-backed ZIP writer used by mobile backup export.
@@ -18,6 +29,10 @@ export interface ExpoZipWriter extends ZipWriter {
 
 /**
  * Adapts an Expo file into a chunk source for the streaming ZIP writer.
+ *
+ * The source keeps one native handle open for the whole file instead of
+ * paying an open/close round-trip per chunk, and periodically yields a
+ * macrotask so the UI can render between chunks.
  */
 function createFileZipChunkSource(
   fileOrUri: File | string,
@@ -29,9 +44,27 @@ function createFileZipChunkSource(
   return {
     size: BigInt(fileSize),
     async *chunks(): AsyncIterable<Uint8Array> {
-      for (let offset = 0; offset < fileSize; offset += chunkSize) {
-        const length = Math.min(chunkSize, fileSize - offset);
-        yield readFileBytesRange(file, offset, length);
+      const handle = file.open();
+      try {
+        let bytesSinceYield = 0;
+        for (let offset = 0; offset < fileSize; offset += chunkSize) {
+          const length = Math.min(chunkSize, fileSize - offset);
+          handle.offset = offset;
+          const chunk = handle.readBytes(length);
+          if (chunk.length !== length) {
+            throw new Error(`File shrank while being added to the ZIP: ${file.uri}`);
+          }
+
+          bytesSinceYield += length;
+          if (bytesSinceYield >= YIELD_INTERVAL_BYTES) {
+            bytesSinceYield = 0;
+            await yieldToEventLoop();
+          }
+
+          yield chunk;
+        }
+      } finally {
+        handle.close();
       }
     },
   };

--- a/apps/mobile/src/lib/zip/adapters/expo/random-access-reader.ts
+++ b/apps/mobile/src/lib/zip/adapters/expo/random-access-reader.ts
@@ -1,16 +1,22 @@
-import { File } from 'expo-file-system';
+import { File, type FileHandle } from 'expo-file-system';
 import { toSafeNumber } from '../../core';
-import { getFileByteSize, readFileBytesRange } from './file-bytes';
+import { getFileByteSize } from './file-bytes';
 import type { ZipReaderSource } from '../../reader/random-access-reader';
 
 /**
  * Adapts Expo FileSystem files into the ZIP random-access reader contract.
+ *
+ * One file handle is opened lazily and reused across reads — imports issue
+ * several reads per entry, and opening a native handle per read is measurable
+ * overhead on archives with many entries. The handle is released by close(),
+ * which openZipReader/ZipReader.close() always invoke, including on failure.
  */
 export function createExpoZipReaderSource(
 	fileOrUri: File | string,
 ): ZipReaderSource {
 	const file = typeof fileOrUri === 'string' ? new File(fileOrUri) : fileOrUri;
 	const fileSize = getFileByteSize(file);
+	let handle: FileHandle | null = null;
 
 	return {
 		async size(): Promise<bigint> {
@@ -27,7 +33,16 @@ export function createExpoZipReaderSource(
 				throw new Error('Invalid ZIP archive: requested byte range is outside the file');
 			}
 
-			return readFileBytesRange(file, start, length);
+			handle ??= file.open();
+			handle.offset = start;
+			return handle.readBytes(length);
+		},
+		async close(): Promise<void> {
+			if (handle) {
+				const openHandle = handle;
+				handle = null;
+				openHandle.close();
+			}
 		},
 	};
 }

--- a/apps/mobile/src/lib/zip/core/core-safety.test.ts
+++ b/apps/mobile/src/lib/zip/core/core-safety.test.ts
@@ -1,5 +1,28 @@
 import { readUint } from './byte-io';
+import { computeCrc32, updateCrc32 } from './crc32';
 import { deflateRaw, inflateRaw } from './deflate-codec';
+
+/** Bitwise reference CRC32 used to validate the table-driven implementation. */
+function referenceCrc32(buffer: Uint8Array): number {
+  let current = 0xffffffff;
+  for (const byte of buffer) {
+    current ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      current = current & 1 ? 0xedb88320 ^ (current >>> 1) : current >>> 1;
+    }
+  }
+  return (current ^ 0xffffffff) >>> 0;
+}
+
+function pseudoRandomBytes(length: number, seed: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  let state = seed;
+  for (let index = 0; index < length; index += 1) {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    bytes[index] = state >>> 24;
+  }
+  return bytes;
+}
 
 describe('core safety', () => {
   test('readUint handles full 32-bit unsigned values', () => {
@@ -18,5 +41,55 @@ describe('core safety', () => {
     expect(() => inflateRaw(truncated)).toThrow(
       'Invalid DEFLATE data: truncated bitstream',
     );
+  });
+
+  test('computeCrc32 matches the CRC32 check value and a bitwise reference', () => {
+    const check = new TextEncoder().encode('123456789');
+    expect(computeCrc32(check, 0, check.length)).toBe(0xcbf43926);
+
+    // Length 1027 is deliberately not a multiple of 8 so the slice-by-8 fast
+    // path and the byte-at-a-time tail are both exercised.
+    const bytes = pseudoRandomBytes(1027, 42);
+    expect(computeCrc32(bytes, 0, bytes.length)).toBe(referenceCrc32(bytes));
+    expect(computeCrc32(bytes, 5, 900)).toBe(
+      referenceCrc32(bytes.subarray(5, 905)),
+    );
+  });
+
+  test('updateCrc32 chained over arbitrary splits matches a single pass', () => {
+    const bytes = pseudoRandomBytes(4096, 7);
+    const whole = computeCrc32(bytes, 0, bytes.length);
+
+    for (const splitAt of [0, 1, 7, 8, 9, 1000, 4095, 4096]) {
+      let checksum = 0xffffffff;
+      checksum = updateCrc32(checksum, bytes, 0, splitAt);
+      checksum = updateCrc32(checksum, bytes, splitAt, bytes.length - splitAt);
+      expect((checksum ^ 0xffffffff) >>> 0).toBe(whole);
+    }
+  });
+
+  test('inflateRaw round-trips into an exactly sized destination buffer', () => {
+    const compressible = new TextEncoder().encode('hello hello hello '.repeat(50));
+    const incompressible = pseudoRandomBytes(70000, 3);
+
+    for (const source of [compressible, incompressible]) {
+      const output = new Uint8Array(source.length);
+      inflateRaw(deflateRaw(source), output);
+      expect(output).toEqual(source);
+    }
+  });
+
+  test('inflateRaw rejects output larger than the provided buffer', () => {
+    // Compressible input decodes through the Huffman literal/match paths;
+    // incompressible input decodes through the stored-block path.
+    const compressible = new TextEncoder().encode('hello hello hello '.repeat(50));
+    const incompressible = pseudoRandomBytes(70000, 3);
+
+    for (const source of [compressible, incompressible]) {
+      const compressed = deflateRaw(source);
+      expect(() => inflateRaw(compressed, new Uint8Array(source.length - 1))).toThrow(
+        'Invalid DEFLATE data: output exceeds the declared size',
+      );
+    }
   });
 });

--- a/apps/mobile/src/lib/zip/core/core-safety.test.ts
+++ b/apps/mobile/src/lib/zip/core/core-safety.test.ts
@@ -79,6 +79,46 @@ describe('core safety', () => {
     }
   });
 
+  test('inflateRaw rejects streams that underfill a fixed destination buffer', () => {
+    const compressible = new TextEncoder().encode('hello hello hello '.repeat(50));
+    const incompressible = pseudoRandomBytes(70000, 3);
+
+    // A destination one byte larger than the decoded payload must not be
+    // silently zero-padded.
+    for (const source of [compressible, incompressible]) {
+      const compressed = deflateRaw(source);
+      expect(() => inflateRaw(compressed, new Uint8Array(source.length + 1))).toThrow(
+        'Invalid DEFLATE data: output is smaller than the declared size',
+      );
+    }
+
+    // The 0x03 0x00 empty-stream fast path must obey the same rule.
+    const emptyStream = deflateRaw(new Uint8Array(0));
+    expect(Array.from(emptyStream)).toEqual([3, 0]);
+    expect(() => inflateRaw(emptyStream, new Uint8Array(1))).toThrow(
+      'Invalid DEFLATE data: output is smaller than the declared size',
+    );
+    expect(inflateRaw(emptyStream, new Uint8Array(0))).toEqual(new Uint8Array(0));
+    expect(inflateRaw(emptyStream)).toEqual(new Uint8Array(0));
+  });
+
+  test('inflateRaw rejects reserved distance symbols 30 and 31', () => {
+    // Hand-assembled fixed-Huffman blocks: final-block bit, block type 01,
+    // length symbol 257 (a three-byte match), then the reserved distance
+    // symbol. Real encoders never emit distance codes above 29.
+    const reservedSymbol30 = new Uint8Array([0x03, 0x3e]);
+    const reservedSymbol31 = new Uint8Array([0x03, 0x7e]);
+
+    for (const stream of [reservedSymbol30, reservedSymbol31]) {
+      expect(() => inflateRaw(stream, new Uint8Array(3))).toThrow(
+        'Invalid DEFLATE data: reserved distance symbol',
+      );
+      expect(() => inflateRaw(stream)).toThrow(
+        'Invalid DEFLATE data: reserved distance symbol',
+      );
+    }
+  });
+
   test('inflateRaw rejects output larger than the provided buffer', () => {
     // Compressible input decodes through the Huffman literal/match paths;
     // incompressible input decodes through the stored-block path.

--- a/apps/mobile/src/lib/zip/core/crc32.ts
+++ b/apps/mobile/src/lib/zip/core/crc32.ts
@@ -1,17 +1,30 @@
 /**
  * CRC32 implementation used by ZIP local and central directory records.
+ *
+ * Uses the slice-by-8 variant: 8 lookup tables let the hot loop consume 8
+ * bytes per iteration, which matters because export runs this over every
+ * stored media byte on the interpreted (Hermes) JS thread.
  */
 
-const crcTable = (() => {
-  const table = new Uint32Array(256);
+const CRC_TABLES = (() => {
+  const tables = new Uint32Array(256 * 8);
+
   for (let value = 0; value < 256; value += 1) {
     let current = value;
     for (let iteration = 0; iteration < 8; iteration += 1) {
       current = current & 1 ? 0xedb88320 ^ (current >>> 1) : current >>> 1;
     }
-    table[value] = current;
+    tables[value] = current;
   }
-  return table;
+
+  for (let slice = 1; slice < 8; slice += 1) {
+    for (let value = 0; value < 256; value += 1) {
+      const previous = tables[(slice - 1) * 256 + value];
+      tables[slice * 256 + value] = (previous >>> 8) ^ tables[previous & 0xff];
+    }
+  }
+
+  return tables;
 })();
 
 export function updateCrc32(
@@ -21,9 +34,33 @@ export function updateCrc32(
   length: number,
 ): number {
   let current = checksum;
-  for (let index = 0; index < length; index += 1) {
-    current = crcTable[(current ^ buffer[offset + index]) & 0xff] ^ (current >>> 8);
+  let index = offset;
+  const end = offset + length;
+  const end8 = offset + (length & ~7);
+
+  while (index < end8) {
+    current ^=
+      buffer[index] |
+      (buffer[index + 1] << 8) |
+      (buffer[index + 2] << 16) |
+      (buffer[index + 3] << 24);
+    current =
+      CRC_TABLES[1792 + (current & 0xff)] ^
+      CRC_TABLES[1536 + ((current >>> 8) & 0xff)] ^
+      CRC_TABLES[1280 + ((current >>> 16) & 0xff)] ^
+      CRC_TABLES[1024 + (current >>> 24)] ^
+      CRC_TABLES[768 + buffer[index + 4]] ^
+      CRC_TABLES[512 + buffer[index + 5]] ^
+      CRC_TABLES[256 + buffer[index + 6]] ^
+      CRC_TABLES[buffer[index + 7]];
+    index += 8;
   }
+
+  while (index < end) {
+    current = CRC_TABLES[(current ^ buffer[index]) & 0xff] ^ (current >>> 8);
+    index += 1;
+  }
+
   return current;
 }
 

--- a/apps/mobile/src/lib/zip/core/deflate-codec.ts
+++ b/apps/mobile/src/lib/zip/core/deflate-codec.ts
@@ -954,6 +954,12 @@ function writeHuffmanSymbol(
  */
 export function inflateRaw(data: Uint8Array, buffer?: Uint8Array): Uint8Array {
   if (data[0] === 3 && data[1] === 0) {
+    // An empty stream must not silently satisfy a non-empty fixed destination:
+    // the ZIP read path sizes the buffer from the declared uncompressed size,
+    // and returning it untouched would yield all-zero bytes for the entry.
+    if (buffer != null && buffer.length !== 0) {
+      throw new Error('Invalid DEFLATE data: output is smaller than the declared size');
+    }
     return buffer ?? new Uint8Array(0);
   }
 
@@ -1102,6 +1108,13 @@ export function inflateRaw(data: Uint8Array, buffer?: Uint8Array): Uint8Array {
       const distanceCode = distanceMap[read17Bits(data, position) & distanceMask];
       position += distanceCode & 15;
       const distanceLiteral = distanceCode >>> 4;
+      // DEFLATE reserves distance symbols 30 and 31. The decode table carries
+      // 65535-byte sentinel entries for them, which `distance > offset` only
+      // catches while less than 64 KB of output exists — beyond that a crafted
+      // stream would silently copy from the wrong position.
+      if (distanceLiteral > 29) {
+        throw new Error('Invalid DEFLATE data: reserved distance symbol');
+      }
       const distanceExtra = state.distanceDefs[distanceLiteral];
       const distance =
         (distanceExtra >>> 4) + readBitsFast(data, position, distanceExtra & 15);
@@ -1137,6 +1150,13 @@ export function inflateRaw(data: Uint8Array, buffer?: Uint8Array): Uint8Array {
         offset += 1;
       }
     }
+  }
+
+  // Overflow throws inside the loop, so a length mismatch here can only mean
+  // the stream produced fewer bytes than the fixed destination declares; the
+  // untouched tail would otherwise pass through as silent zero padding.
+  if (!shouldGrowBuffer && offset !== output!.length) {
+    throw new Error('Invalid DEFLATE data: output is smaller than the declared size');
   }
 
   return output!.length === offset ? output! : output!.slice(0, offset);

--- a/apps/mobile/src/lib/zip/core/deflate-codec.ts
+++ b/apps/mobile/src/lib/zip/core/deflate-codec.ts
@@ -1,3 +1,32 @@
+/**
+ * Pure-JS DEFLATE codec used by the ZIP read/write paths.
+ *
+ * Derived from UZIP.js (https://github.com/photopea/UZIP.js),
+ * Copyright (c) 2018 Photopea, released under the MIT License:
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a
+ *   copy of this software and associated documentation files (the "Software"),
+ *   to deal in the Software without restriction, including without limitation
+ *   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *   and/or sell copies of the Software, and to permit persons to whom the
+ *   Software is furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included
+ *   in all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *   DEALINGS IN THE SOFTWARE.
+ *
+ * Local changes relative to UZIP.js include TypeScript typing, renamed
+ * identifiers, bitstream bounds guards, and output-capacity checks during
+ * inflate.
+ */
+
 // ─── Internal types ─────────────────────────────────────────────────────────
 // These are implementation details of the DEFLATE codec and are not part of
 // the public ZIP API surface.
@@ -934,6 +963,12 @@ export function inflateRaw(data: Uint8Array, buffer?: Uint8Array): Uint8Array {
     output = new Uint8Array((data.length >>> 2) << 3);
   }
 
+  // When the caller provides a fixed destination (the ZIP read path sizes it
+  // from the declared uncompressed size), overflowing it must be an error.
+  // Without this check, out-of-bounds typed-array writes are silent no-ops
+  // and corrupt archives would decode to silently wrong bytes.
+  const capacity = shouldGrowBuffer ? Infinity : output!.length;
+
   let finalBlock = 0;
   let position = 0;
   let offset = 0;
@@ -954,6 +989,9 @@ export function inflateRaw(data: Uint8Array, buffer?: Uint8Array): Uint8Array {
 
       const byteOffset = (position >>> 3) + 4;
       const length = data[byteOffset - 4] | (data[byteOffset - 3] << 8);
+      if (offset + length > capacity) {
+        throw new Error('Invalid DEFLATE data: output exceeds the declared size');
+      }
       if (shouldGrowBuffer) {
         output = ensureInflateBuffer(output!, offset + length);
       }
@@ -1039,6 +1077,12 @@ export function inflateRaw(data: Uint8Array, buffer?: Uint8Array): Uint8Array {
       const literal = code >>> 4;
 
       if (literal >>> 8 === 0) {
+        if (offset >= output!.length) {
+          if (!shouldGrowBuffer) {
+            throw new Error('Invalid DEFLATE data: output exceeds the declared size');
+          }
+          output = ensureInflateBuffer(output!, offset + (1 << 17));
+        }
         output![offset] = literal;
         offset += 1;
         continue;
@@ -1062,6 +1106,15 @@ export function inflateRaw(data: Uint8Array, buffer?: Uint8Array): Uint8Array {
       const distance =
         (distanceExtra >>> 4) + readBitsFast(data, position, distanceExtra & 15);
       position += distanceExtra & 15;
+
+      if (distance > offset) {
+        throw new Error(
+          'Invalid DEFLATE data: match distance points before the output start',
+        );
+      }
+      if (end > capacity) {
+        throw new Error('Invalid DEFLATE data: output exceeds the declared size');
+      }
 
       if (shouldGrowBuffer) {
         output = ensureInflateBuffer(output!, offset + (1 << 17));

--- a/apps/mobile/src/lib/zip/index.ts
+++ b/apps/mobile/src/lib/zip/index.ts
@@ -1,19 +1,37 @@
-export * from './reader';
-export * from './writer';
-export * from './adapters/expo';
+/**
+ * App-facing ZIP facade.
+ *
+ * Only the scalable, file-backed surface is exported here — this is what real
+ * import/export flows should use. The in-memory helpers (parseZipArchive,
+ * createMemoryZipWriter, readZipEntry*, createMemoryZipReaderSource) are
+ * intentionally not re-exported: they exist for tests, fixtures, and tiny
+ * archives, and keeping them off the facade stops app code from growing
+ * accidental dependencies on them. Import them from
+ * `~/lib/zip/reader/memory-reader` and `~/lib/zip/writer/memory-writer`
+ * directly when writing tests.
+ */
+export {
+  openZipReader,
+  type ZipEntryInfo,
+  type ZipReader,
+  type ZipReaderSource,
+} from './reader/random-access-reader';
+
+export {
+  createZipWriter,
+  type ZipChunkSource,
+  type ZipOutputSink,
+  type ZipWriter,
+} from './writer/sequential-writer';
+
+export {
+  createExpoZipReaderSource,
+  createExpoZipWriter,
+  type ExpoZipWriter,
+} from './adapters/expo';
+
 export {
   createZipEntryLookup,
   type ZipEntryLookup,
   type ZipEntryLookupSource,
 } from './zip-entry-lookup';
-
-export {
-  encodeZipArchiveBytes,
-  parseZipArchiveBytes,
-  type ParsedLocalFileHeader,
-  type ParsedZipDirectory,
-  type ParsedZipEntryMeta,
-} from './core';
-
-// Keep the app-facing ZIP surface small: callers should prefer this facade
-// rather than importing deep internal modules.

--- a/apps/mobile/src/lib/zip/reader/random-access-reader.ts
+++ b/apps/mobile/src/lib/zip/reader/random-access-reader.ts
@@ -302,6 +302,12 @@ class ZipReaderImpl implements ZipReader {
     const nameLength = readUshort(localHeaderPrefix, 26);
     const extraLength = readUshort(localHeaderPrefix, 28);
     const localHeaderLength = 30 + nameLength + extraLength;
+    // readExact would also fail on a short read, but only if the source
+    // short-reads at EOF; the ZipReaderSource contract does not guarantee
+    // that, so enforce the archive bounds here instead of relying on it.
+    if (BigInt(localHeaderLength) > availableBytes) {
+      throw new Error('Invalid ZIP archive: local file header is truncated');
+    }
     const localHeaderBytes =
       localHeaderLength <= localHeaderPrefix.length
         ? localHeaderPrefix
@@ -322,6 +328,9 @@ class ZipReaderImpl implements ZipReader {
       `Uncompressed size for ${path}`,
     );
     const dataOffset = entry.localHeaderOffset + BigInt(localHeader.dataOffset);
+    if (dataOffset + entry.compressedSize > this.archiveSize) {
+      throw new Error(`Invalid ZIP archive: ZIP entry data for ${path} is truncated`);
+    }
     const compressedBytes = await readExact(
       this.reader,
       dataOffset,

--- a/apps/mobile/src/lib/zip/reader/random-access-reader.ts
+++ b/apps/mobile/src/lib/zip/reader/random-access-reader.ts
@@ -19,7 +19,6 @@ import {
   ZIP64_END_OF_CENTRAL_DIRECTORY_SIGNATURE,
   ZIP64_EOCD_RECORD_DATA_SIZE,
 } from '../core';
-import { cloneBytes } from '../shared/bytes';
 import { ensureTextDecoder } from '../shared/text-codec';
 import type { ParsedZipEntryMeta } from '../core';
 
@@ -31,6 +30,11 @@ const ZIP_TAIL_READ_SIZE =
  */
 export interface ZipReaderSource {
   size(): Promise<bigint>;
+  /**
+   * Must resolve with a buffer the caller may keep and mutate — never a view
+   * into state the source will reuse for later reads. The reader hands these
+   * bytes to app code without defensive copying.
+   */
   read(offset: bigint, length: number): Promise<Uint8Array>;
   close?(): Promise<void> | void;
 }
@@ -229,6 +233,13 @@ function createEntryInfo(entry: ParsedZipEntryMeta): ZipEntryInfo {
   };
 }
 
+/**
+ * Local file headers are usually 30 bytes plus a short filename, so one read
+ * of this size almost always covers the whole header and avoids a second
+ * round-trip to the byte source per entry.
+ */
+const LOCAL_HEADER_PREFETCH_SIZE = 256;
+
 class ZipReaderImpl implements ZipReader {
   private closed = false;
   private readonly entries: readonly ZipEntryInfo[];
@@ -237,6 +248,7 @@ class ZipReaderImpl implements ZipReader {
   constructor(
     private readonly reader: ZipReaderSource,
     parsedEntries: ParsedZipEntryMeta[],
+    private readonly archiveSize: bigint,
   ) {
     this.entries = parsedEntries.map(createEntryInfo);
     this.entriesByPath = new Map(parsedEntries.map((entry) => [entry.path, entry]));
@@ -267,10 +279,19 @@ class ZipReaderImpl implements ZipReader {
       throw new Error('Unsupported ZIP feature: encrypted entries are not supported');
     }
 
+    const availableBytes = this.archiveSize - entry.localHeaderOffset;
+    if (availableBytes < 30n) {
+      throw new Error('Invalid ZIP archive: local file header is truncated');
+    }
+
+    const prefetchLength =
+      availableBytes < BigInt(LOCAL_HEADER_PREFETCH_SIZE)
+        ? Number(availableBytes)
+        : LOCAL_HEADER_PREFETCH_SIZE;
     const localHeaderPrefix = await readExact(
       this.reader,
       entry.localHeaderOffset,
-      30,
+      prefetchLength,
       'local file header',
     );
 
@@ -282,7 +303,7 @@ class ZipReaderImpl implements ZipReader {
     const extraLength = readUshort(localHeaderPrefix, 28);
     const localHeaderLength = 30 + nameLength + extraLength;
     const localHeaderBytes =
-      localHeaderLength === localHeaderPrefix.length
+      localHeaderLength <= localHeaderPrefix.length
         ? localHeaderPrefix
         : await readExact(
             this.reader,
@@ -318,7 +339,9 @@ class ZipReaderImpl implements ZipReader {
         );
       }
 
-      return cloneBytes(compressedBytes);
+      // The ZipReaderSource contract guarantees read() results are caller-owned,
+      // so returning them directly avoids a second full-entry allocation.
+      return compressedBytes;
     }
 
     if (localHeader.compressionMethod === ZIP_COMPRESSION_METHOD_DEFLATE) {
@@ -363,25 +386,38 @@ class ZipReaderImpl implements ZipReader {
 
 /**
  * Opens a ZIP archive from a random-access byte reader without loading every file entry.
+ *
+ * On failure the source is closed before the error propagates, so callers do
+ * not leak file handles when handed an invalid archive.
  */
 export async function openZipReader(reader: ZipReaderSource): Promise<ZipReader> {
-  const directory = await readDirectoryRecord(reader);
-  const centralDirectorySize = toSafeNumber(
-    directory.centralDirectorySize,
-    'Central directory size',
-  );
-  const centralDirectoryBytes = await readExact(
-    reader,
-    directory.centralDirectoryOffset,
-    centralDirectorySize,
-    'central directory',
-  );
-  const entries = parseZipCentralDirectoryEntries(
-    centralDirectoryBytes,
-    directory.entryCount,
-  );
+  try {
+    const archiveSize = await reader.size();
+    const directory = await readDirectoryRecord(reader);
+    const centralDirectorySize = toSafeNumber(
+      directory.centralDirectorySize,
+      'Central directory size',
+    );
+    const centralDirectoryBytes = await readExact(
+      reader,
+      directory.centralDirectoryOffset,
+      centralDirectorySize,
+      'central directory',
+    );
+    const entries = parseZipCentralDirectoryEntries(
+      centralDirectoryBytes,
+      directory.entryCount,
+    );
 
-  return new ZipReaderImpl(reader, entries);
+    return new ZipReaderImpl(reader, entries, archiveSize);
+  } catch (error) {
+    try {
+      await reader.close?.();
+    } catch {
+      // Preserve the original open/parse failure.
+    }
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
- rewrite CRC32 as slice-by-8, the main cost on stored media during export
- reuse one FileHandle per reader/writer and prefetch local headers in a single read instead of three
- yield to the event loop during export chunking and import asset materialization so large backups no longer freeze the UI
- reject DEFLATE output that exceeds the declared size instead of silently truncating; cover crc32 and inflate bounds with new core-safety tests
- add the missing MIT attribution header for UZIP.js in deflate-codec.ts
- export only the scalable surface from ~/lib/zip; tests deep-import the in-memory helpers
- set EXPO_PUBLIC_USE_RN_FETCH=1 via jest globalSetup to fix intermittent exit-code-1 on passing runs and the "Cannot log after tests are done" noise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved ZIP import/export responsiveness by yielding between heavy media operations and streaming Expo file reads to avoid repeated file reopening.
  - Enhanced CRC32 throughput and efficiency, plus added prefetching/boundary checks during ZIP reads.

- **Reliability**
  - Strengthened ZIP validation, including stricter bounds for truncated archives and safer `inflateRaw` fixed-buffer behavior.
  - Improved native file-handle lifecycle handling for ZIP reader sources.

- **Documentation**
  - Updated ZIP guidance to reflect the supported in-memory ZIP utility entry points.

- **Tests**
  - Expanded CRC32 and decompression boundary tests for correctness and error messaging.

- **New Features**
  - Added Jest global setup to ensure the test environment correctly inherits Expo fetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->