### PR TITLE
feat: add restart action to update success toast

### DIFF
--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -436,6 +436,7 @@ export const ar: Translations = {
   'Checking for updates…': 'جارٍ التحقق من التحديثات…',
   'Last checked: {time}': 'آخر تحقق: {time}',
   Never: 'أبدًا',
+  Restart: 'إعادة التشغيل',
   'Restart to apply': 'أعد التشغيل للتطبيق',
   'Update downloaded. Restart to apply it.': 'تم تنزيل التحديث. أعد التشغيل لتطبيقه.',
   'You already have the latest version': 'لديك أحدث إصدار بالفعل',

--- a/apps/mobile/src/lib/i18n/translations/de.ts
+++ b/apps/mobile/src/lib/i18n/translations/de.ts
@@ -474,6 +474,7 @@ export const de: Translations = {
   'Checking for updates…': 'Updates werden gesucht …',
   'Last checked: {time}': 'Zuletzt geprüft: {time}',
   Never: 'Nie',
+  Restart: 'Neu starten',
   'Restart to apply': 'Zum Anwenden neu starten',
   'Update downloaded. Restart to apply it.':
     'Update heruntergeladen. Starte die App neu, um es anzuwenden.',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -451,6 +451,7 @@ export const en = {
   'Checking for updates…': 'Checking for updates…',
   'Last checked: {time}': 'Last checked: {time}',
   Never: 'Never',
+  Restart: 'Restart',
   'Restart to apply': 'Restart to apply',
   'Update downloaded. Restart to apply it.': 'Update downloaded. Restart to apply it.',
   'You already have the latest version': 'You already have the latest version',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -435,6 +435,7 @@ export const he: Translations = {
   'Checking for updates…': 'בודק עדכונים…',
   'Last checked: {time}': 'בדיקה אחרונה: {time}',
   Never: 'מעולם לא',
+  Restart: 'הפעלה מחדש',
   'Restart to apply': 'הפעלה מחדש להחלה',
   'Update downloaded. Restart to apply it.': 'העדכון ירד. הפעל מחדש כדי להחיל אותו.',
   'You already have the latest version': 'הגרסה האחרונה כבר מותקנת',

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -423,6 +423,7 @@ export const zhCN: Translations = {
   'Checking for updates…': '正在检查更新…',
   'Last checked: {time}': '上次检查：{time}',
   Never: '从未',
+  Restart: '重启',
   'Restart to apply': '重启以应用',
   'Update downloaded. Restart to apply it.': '更新已下载。重启以应用。',
   'You already have the latest version': '您已使用最新版本',

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -425,6 +425,7 @@ export const zhTW: Translations = {
   'Checking for updates…': '正在檢查更新…',
   'Last checked: {time}': '上次檢查：{time}',
   Never: '從未',
+  Restart: '重新啟動',
   'Restart to apply': '重新啟動以套用',
   'Update downloaded. Restart to apply it.': '更新已下載。重新啟動以套用。',
   'You already have the latest version': '您已使用最新版本',

--- a/apps/mobile/src/screens/settings/sections/AppInfoSection.tsx
+++ b/apps/mobile/src/screens/settings/sections/AppInfoSection.tsx
@@ -64,6 +64,15 @@ export function AppInfoSection() {
       : t('Never');
   const isUpdateBusy = isManualCheckRunning || isChecking || isDownloading;
 
+  const handleRestart = async () => {
+    try {
+      await restartToApplyAppUpdate();
+    } catch (error) {
+      console.warn('Failed to restart to apply the downloaded update:', error);
+      toast.error(t('Unable to update'));
+    }
+  };
+
   const handleCheckForUpdates = async () => {
     setIsManualCheckRunning(true);
     try {
@@ -77,7 +86,12 @@ export function AppInfoSection() {
         // need to expand the end-user translation catalog.
         toast.info('Updates are unavailable in development builds');
       } else if (result === 'downloaded') {
-        toast.success(t('Update downloaded. Restart to apply it.'));
+        toast.success(t('Update downloaded. Restart to apply it.'), {
+          action: {
+            label: t('Restart'),
+            onPress: () => void handleRestart(),
+          },
+        });
       } else {
         toast.success(t('You already have the latest version'));
       }
@@ -86,15 +100,6 @@ export function AppInfoSection() {
       toast.error(t('Unable to update'));
     } finally {
       setIsManualCheckRunning(false);
-    }
-  };
-
-  const handleRestart = async () => {
-    try {
-      await restartToApplyAppUpdate();
-    } catch (error) {
-      console.warn('Failed to restart to apply the downloaded update:', error);
-      toast.error(t('Unable to update'));
     }
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a localized **Restart** action to the app update notification.
  - Users can now restart the app to apply downloaded updates.
  - Added Restart translations for Arabic, German, English, Hebrew, Simplified Chinese, and Traditional Chinese.

- **Bug Fixes**
  - Improved handling of errors that occur while applying downloaded updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->