### PR TITLE
feat(mobile): add achievement celebrations and entry image sharing

### DIFF
--- a/apps/mobile/__mocks__/expo-file-system.ts
+++ b/apps/mobile/__mocks__/expo-file-system.ts
@@ -10,6 +10,7 @@ export const __mockFileSystemState = {
   cacheEntries: [] as unknown[],
   createdFiles: [] as unknown[],
   copyBehavior: async (_source: unknown, _destination: unknown) => {},
+  moveBehavior: async (_source: unknown, _destination: unknown) => {},
   paths: {
     cache: '/tmp',
     document: '/documents',
@@ -24,6 +25,13 @@ export class File {
   copy = jest.fn((destination: unknown) =>
     __mockFileSystemState.copyBehavior(this, destination),
   );
+  // Matches the real API: a move repoints this file at its new location.
+  move = jest.fn(async (destination: unknown) => {
+    await __mockFileSystemState.moveBehavior(this, destination);
+    if (destination && typeof destination === 'object' && 'uri' in destination) {
+      this.uri = String((destination as { uri?: unknown }).uri ?? this.uri);
+    }
+  });
   uri: string;
 
   constructor(...args: unknown[]) {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tackbok/mobile",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
@@ -65,6 +65,7 @@
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.26.2",
     "react-native-svg": "15.15.4",
+    "react-native-view-shot": "^5.1.1",
     "react-native-worklets": "0.10.0",
     "tailwind-variants": "^3.2.2",
     "tailwindcss": "^4.3.0",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -27,6 +27,7 @@ import { PortalHost } from '~/components/primitives/portal';
 import { Text } from '~/components/ui/text';
 import { Toaster } from '~/components/ui/toast';
 import { APP_FONT_ASSETS } from '~/lib/theme/fonts';
+import { AchievementDialogHost } from '~/components/achievement-dialog-host';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -185,6 +186,10 @@ export default function Layout() {
                   }}
                 />
                 <Stack.Screen
+                  name="share-entry/[noteId]"
+                  options={{ title: 'Share Entry', headerShown: false }}
+                />
+                <Stack.Screen
                   name="insights"
                   options={{
                     title: 'Insights',
@@ -208,6 +213,7 @@ export default function Layout() {
               </Stack>
               <ReminderNavigationObserver />
               <ScreenViewObserver />
+              <AchievementDialogHost />
             </AppLockGate>
             <StatusBar style={themeConfig.variant === 'dark' ? 'light' : 'dark'} />
             <Toaster />

--- a/apps/mobile/src/app/share-entry/[noteId].tsx
+++ b/apps/mobile/src/app/share-entry/[noteId].tsx
@@ -1,0 +1,8 @@
+import { useLocalSearchParams } from 'expo-router';
+import { EntryShareScreen } from '~/screens/sharing/entry-share-screen';
+
+export default function ShareEntryRoute() {
+  const { noteId } = useLocalSearchParams<{ noteId: string }>();
+  return <EntryShareScreen noteId={noteId} />;
+}
+

--- a/apps/mobile/src/components/achievement-dialog-host.tsx
+++ b/apps/mobile/src/components/achievement-dialog-host.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { ActivityIndicator, Platform, View } from 'react-native';
+import * as Haptics from 'expo-haptics';
+import { X } from 'lucide-react-native';
+import { useTranslation, formatLocalizedNumber } from '~/lib/i18n';
+import { useSettingsStore } from '~/lib/settings';
+import { getTitleFont, resolveTitleFontId } from '~/lib/theme/typography';
+import { useAchievementDialogStore } from '~/lib/achievement-dialog';
+import { getSharePalette } from '~/lib/sharing/share-palettes';
+import { ACHIEVEMENT_SHARE_OUTPUT } from '~/lib/sharing/share-layouts';
+import { useShareImage } from '~/lib/sharing/use-share-image';
+import { AchievementShareCard } from '~/components/sharing/achievement-share-card';
+import { Button } from '~/components/ui/button';
+import { Icon } from '~/components/ui/icon';
+import { Text } from '~/components/ui/text';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '~/components/ui/dialog';
+
+/** Time the iOS full-window overlay needs to finish its exit transition. */
+const OVERLAY_EXIT_MS = 200;
+
+export function AchievementDialogHost() {
+  const { t, locale } = useTranslation();
+  const theme = useSettingsStore((state) => state.theme);
+  const titleFont = useSettingsStore((state) => state.titleFont);
+  const pendingAchievement = useSettingsStore((state) => state.pendingAchievement);
+  const setPendingAchievement = useSettingsStore((state) => state.setPendingAchievement);
+  const manualAchievement = useAchievementDialogStore((state) => state.manualAchievement);
+  const closeManualAchievement = useAchievementDialogStore(
+    (state) => state.closeManualAchievement,
+  );
+  const achievement = manualAchievement ?? pendingAchievement;
+  const isManual = manualAchievement !== null;
+  const palette = getSharePalette(theme);
+  const titleFontFamily = getTitleFont(resolveTitleFontId(theme, titleFont)).fontFamily;
+  const captureRef = React.useRef<View>(null);
+  const [visible, setVisible] = React.useState(false);
+  const [captureReady, setCaptureReady] = React.useState(false);
+  const lastHapticAchievement = React.useRef<string | null>(null);
+  // The host is mounted for the whole session; only probe once it has something
+  // to show.
+  const {
+    isAvailable: sharingAvailable,
+    isSharing,
+    share,
+  } = useShareImage({ enabled: visible });
+
+  React.useEffect(() => {
+    let idleHandle: ReturnType<typeof requestIdleCallback> | null = null;
+    const transitionTimer = setTimeout(
+      () => {
+        idleHandle = requestIdleCallback(() => setVisible(Boolean(achievement)), {
+          timeout: 500,
+        });
+      },
+      achievement ? 250 : 0,
+    );
+    return () => {
+      clearTimeout(transitionTimer);
+      if (idleHandle !== null) cancelIdleCallback(idleHandle);
+    };
+  }, [achievement]);
+
+  React.useEffect(() => {
+    if (!visible) return;
+    if (
+      Platform.OS === 'ios' &&
+      !isManual &&
+      achievement &&
+      lastHapticAchievement.current !== achievement.id
+    ) {
+      lastHapticAchievement.current = achievement.id;
+      void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    }
+  }, [achievement, isManual, visible]);
+
+  const clearAchievement = React.useCallback(() => {
+    setVisible(false);
+    setCaptureReady(false);
+    if (isManual) closeManualAchievement();
+    else setPendingAchievement(null);
+  }, [closeManualAchievement, isManual, setPendingAchievement]);
+
+  const handleOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (!open && visible) clearAchievement();
+    },
+    [clearAchievement, visible],
+  );
+
+  const handleReadyChange = React.useCallback((ready: boolean) => {
+    setCaptureReady(ready);
+  }, []);
+
+  const handleShare = React.useCallback(async () => {
+    if (!achievement) return;
+    let hiddenForNativeShare = false;
+
+    const result = await share({
+      ref: captureRef,
+      dialogTitle: t('Share achievement'),
+      filenamePrefix: 'tackbok-achievement',
+      width: ACHIEVEMENT_SHARE_OUTPUT.width,
+      height: ACHIEVEMENT_SHARE_OUTPUT.height,
+      isReady: captureReady,
+      logLabel: 'Achievement image sharing failed',
+      beforePresentShareSheet:
+        Platform.OS === 'ios'
+          ? async () => {
+              // The activity controller would otherwise present behind this
+              // dialog's full-window overlay.
+              hiddenForNativeShare = true;
+              setVisible(false);
+              await new Promise<void>((resolve) => setTimeout(resolve, OVERLAY_EXIT_MS));
+            }
+          : undefined,
+    });
+
+    if (result === 'shared') clearAchievement();
+    // Sharing failed after the handoff already hid the dialog — bring it back so
+    // the celebration is still there to retry.
+    else if (hiddenForNativeShare) setVisible(true);
+  }, [achievement, captureReady, clearAchievement, share, t]);
+
+  if (!achievement) return null;
+
+  const isFirstDay = achievement.variant === 'first-day';
+  const numberLabel = formatLocalizedNumber(achievement.journaledDays, locale);
+  const title = isFirstDay
+    ? t('Day one complete!')
+    : t('{count} days of gratitude!', { count: numberLabel });
+  const message = isFirstDay
+    ? t('A beautiful beginning. Keep noticing the good.')
+    : t('Congratulations on making gratitude part of your journey.');
+
+  return (
+    <Dialog open={visible} onOpenChange={handleOpenChange}>
+      <DialogContent showCloseButton={false} className="w-[92%] max-w-sm gap-4 p-4">
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <DialogDescription className="sr-only">{message}</DialogDescription>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="absolute right-2 top-2 z-10 rounded-full bg-background/80"
+          accessibilityLabel={t('Close')}
+          onPress={clearAchievement}>
+          <Icon as={X} size={18} />
+        </Button>
+
+        <AchievementShareCard
+          ref={captureRef}
+          achievement={achievement}
+          palette={palette}
+          numberLabel={numberLabel}
+          title={title}
+          message={message}
+          titleFontFamily={titleFontFamily}
+          onReadyChange={handleReadyChange}
+        />
+
+        <Button
+          variant="primary"
+          size="lg"
+          disabled={!captureReady || isSharing || sharingAvailable !== true}
+          onPress={() => void handleShare()}>
+          {isSharing ? <ActivityIndicator size="small" /> : null}
+          <Text>{t('Share achievement')}</Text>
+        </Button>
+        {sharingAvailable === false ? (
+          <Text className="text-center text-sm text-destructive">
+            {t('Sharing is not available on this device')}
+          </Text>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/mobile/src/components/sharing/achievement-share-card.tsx
+++ b/apps/mobile/src/components/sharing/achievement-share-card.tsx
@@ -24,24 +24,34 @@ export const AchievementShareCard = React.forwardRef<View, AchievementShareCardP
   ) {
     const firstReadyFrame = React.useRef<number | null>(null);
     const secondReadyFrame = React.useRef<number | null>(null);
+    const hasMeasured = React.useRef(false);
     const countTextStyle = getTitleFontPreviewStyle(titleFontFamily, 88);
     const titleTextStyle = getTitleFontPreviewStyle(titleFontFamily, 29);
 
+    const scheduleReady = React.useCallback(() => {
+      firstReadyFrame.current = requestAnimationFrame(() => {
+        secondReadyFrame.current = requestAnimationFrame(() => onReadyChange?.(true));
+      });
+    }, [onReadyChange]);
+
     React.useEffect(() => {
       onReadyChange?.(false);
+      // The frame keeps a fixed aspect ratio, so `onLayout` only ever fires on
+      // mount. Once measured, a later prop change has to reschedule the ready
+      // signal itself or the card would stay not-ready forever.
+      if (hasMeasured.current) scheduleReady();
       return () => {
         if (firstReadyFrame.current !== null)
           cancelAnimationFrame(firstReadyFrame.current);
         if (secondReadyFrame.current !== null)
           cancelAnimationFrame(secondReadyFrame.current);
       };
-    }, [achievement.id, palette.id, titleFontFamily, onReadyChange]);
+    }, [achievement.id, palette.id, titleFontFamily, onReadyChange, scheduleReady]);
 
     const handleLayout = React.useCallback(() => {
-      firstReadyFrame.current = requestAnimationFrame(() => {
-        secondReadyFrame.current = requestAnimationFrame(() => onReadyChange?.(true));
-      });
-    }, [onReadyChange]);
+      hasMeasured.current = true;
+      scheduleReady();
+    }, [scheduleReady]);
 
     return (
       <ShareCardFrame

--- a/apps/mobile/src/components/sharing/achievement-share-card.tsx
+++ b/apps/mobile/src/components/sharing/achievement-share-card.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { TackbokLogo } from '~/components/TackbokLogo';
+import type { Achievement } from '~/lib/achievements';
+import { ACHIEVEMENT_SHARE_OUTPUT } from '~/lib/sharing/share-layouts';
+import type { SharePalette } from '~/lib/sharing/share-palettes';
+import { getTitleFontPreviewStyle } from '~/lib/theme/typography';
+import { ShareCardFrame } from './share-card-frame';
+
+type AchievementShareCardProps = {
+  achievement: Achievement;
+  palette: SharePalette;
+  numberLabel: string;
+  title: string;
+  message: string;
+  titleFontFamily: string;
+  onReadyChange?: (ready: boolean) => void;
+};
+
+export const AchievementShareCard = React.forwardRef<View, AchievementShareCardProps>(
+  function AchievementShareCard(
+    { achievement, palette, numberLabel, title, message, titleFontFamily, onReadyChange },
+    ref,
+  ) {
+    const firstReadyFrame = React.useRef<number | null>(null);
+    const secondReadyFrame = React.useRef<number | null>(null);
+    const countTextStyle = getTitleFontPreviewStyle(titleFontFamily, 88);
+    const titleTextStyle = getTitleFontPreviewStyle(titleFontFamily, 29);
+
+    React.useEffect(() => {
+      onReadyChange?.(false);
+      return () => {
+        if (firstReadyFrame.current !== null)
+          cancelAnimationFrame(firstReadyFrame.current);
+        if (secondReadyFrame.current !== null)
+          cancelAnimationFrame(secondReadyFrame.current);
+      };
+    }, [achievement.id, palette.id, titleFontFamily, onReadyChange]);
+
+    const handleLayout = React.useCallback(() => {
+      firstReadyFrame.current = requestAnimationFrame(() => {
+        secondReadyFrame.current = requestAnimationFrame(() => onReadyChange?.(true));
+      });
+    }, [onReadyChange]);
+
+    return (
+      <ShareCardFrame
+        ref={ref}
+        palette={palette}
+        aspectRatio={ACHIEVEMENT_SHARE_OUTPUT.aspectRatio}
+        onLayout={handleLayout}>
+        <View
+          style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 15 }}>
+          {achievement.variant === 'first-day' ? (
+            <TackbokLogo size={82} color={palette.foreground} />
+          ) : (
+            <Text
+              allowFontScaling={false}
+              style={{
+                color: palette.foreground,
+                ...countTextStyle,
+                lineHeight: countTextStyle.lineHeight ?? 94,
+                fontVariant: ['tabular-nums'],
+              }}>
+              {numberLabel}
+            </Text>
+          )}
+          <Text
+            allowFontScaling={false}
+            style={{
+              color: palette.foreground,
+              ...titleTextStyle,
+              lineHeight: titleTextStyle.lineHeight ?? 34,
+              textAlign: 'center',
+            }}>
+            {title}
+          </Text>
+          <Text
+            allowFontScaling={false}
+            style={{
+              color: palette.foreground,
+              fontFamily: 'Inter_400Regular',
+              fontSize: 16,
+              lineHeight: 22,
+              textAlign: 'center',
+              maxWidth: 280,
+            }}>
+            {message}
+          </Text>
+        </View>
+      </ShareCardFrame>
+    );
+  },
+);

--- a/apps/mobile/src/components/sharing/entry-share-card.tsx
+++ b/apps/mobile/src/components/sharing/entry-share-card.tsx
@@ -1,0 +1,298 @@
+import React from 'react';
+import { Image, Text, View } from 'react-native';
+import type { Asset } from '~/types';
+import { getFullPhotoUri } from '~/lib/photoUtils';
+import {
+  ENTRY_LAYOUT_CANDIDATES,
+  getFinalBodyLineLimit,
+  SHARE_OUTPUTS,
+  type ShareOutput,
+} from '~/lib/sharing/share-layouts';
+import type { SharePalette } from '~/lib/sharing/share-palettes';
+import { ShareCardFrame } from './share-card-frame';
+
+/** Privacy cap: the strip never shows more of the entry's gallery than this. */
+const MAX_SHARED_PHOTOS = 5;
+const PHOTO_GAP = 8;
+
+type EntryShareCardProps = {
+  dateLabel: string;
+  title: string | null;
+  body: string | null;
+  moodLabel?: string | null;
+  moodEmoji?: string | null;
+  photos?: Asset[];
+  includeMood: boolean;
+  includePhotos: boolean;
+  isRTL: boolean;
+  palette: SharePalette;
+  onReadyChange: (ready: boolean) => void;
+  onOutputChange: (output: ShareOutput) => void;
+};
+
+export const EntryShareCard = React.forwardRef<View, EntryShareCardProps>(
+  function EntryShareCard(
+    {
+      dateLabel,
+      title,
+      body,
+      moodLabel,
+      moodEmoji,
+      photos = [],
+      includeMood,
+      includePhotos,
+      isRTL,
+      palette,
+      onReadyChange,
+      onOutputChange,
+    },
+    ref,
+  ) {
+    const selectedPhotos = React.useMemo(
+      () => photos.slice(0, MAX_SHARED_PHOTOS),
+      [photos],
+    );
+    const photoSourceKey = selectedPhotos.map((photo) => photo.uri).join('|');
+    const [candidateIndex, setCandidateIndex] = React.useState(0);
+    const [measurementToken, setMeasurementToken] = React.useState(0);
+    const [frame, setFrame] = React.useState({ width: 0, height: 0, aspectRatio: 0 });
+    const [contentHeight, setContentHeight] = React.useState(0);
+    const [loadedPhotos, setLoadedPhotos] = React.useState<Set<string>>(new Set());
+    const [failedPhotos, setFailedPhotos] = React.useState<Set<string>>(new Set());
+
+    const candidate = ENTRY_LAYOUT_CANDIDATES[candidateIndex]!;
+    const output = SHARE_OUTPUTS[candidate.outputId];
+    const visiblePhotos = selectedPhotos.filter((photo) => !failedPhotos.has(photo.uri));
+    const photoLoadsSettled =
+      !includePhotos ||
+      selectedPhotos.every(
+        (photo) => loadedPhotos.has(photo.uri) || failedPhotos.has(photo.uri),
+      );
+
+    // A candidate step that changes the canvas also changes the frame height, so
+    // only trust a frame measurement taken at the aspect ratio being rendered.
+    // Otherwise the new content can be compared against the previous, shorter
+    // container and skip a fitting candidate.
+    const availableHeight = frame.aspectRatio === output.aspectRatio ? frame.height : 0;
+
+    // Everything that can change what has to be measured. `palette` is
+    // deliberately absent: colors never affect layout, so a palette change must
+    // not discard a valid measurement — `onLayout` would stay silent afterwards
+    // and the card would never report ready again.
+    React.useEffect(() => {
+      setCandidateIndex(0);
+      setContentHeight(0);
+      // Bumping the token remounts the measured view, which guarantees a fresh
+      // `onLayout` even when the new content happens to be exactly as tall.
+      setMeasurementToken((token) => token + 1);
+      onReadyChange(false);
+    }, [
+      dateLabel,
+      title,
+      body,
+      moodLabel,
+      moodEmoji,
+      includeMood,
+      includePhotos,
+      photoSourceKey,
+      failedPhotos.size,
+      onReadyChange,
+    ]);
+
+    React.useEffect(() => {
+      onOutputChange(output);
+    }, [onOutputChange, output]);
+
+    const overflows = availableHeight > 0 && contentHeight > availableHeight + 1;
+
+    React.useEffect(() => {
+      if (
+        overflows &&
+        !candidate.finalFallback &&
+        candidateIndex < ENTRY_LAYOUT_CANDIDATES.length - 1
+      ) {
+        onReadyChange(false);
+        setCandidateIndex((index) => index + 1);
+        setContentHeight(0);
+      }
+    }, [candidate.finalFallback, candidateIndex, onReadyChange, overflows]);
+
+    React.useEffect(() => {
+      if (
+        availableHeight <= 0 ||
+        contentHeight <= 0 ||
+        !photoLoadsSettled ||
+        (overflows && !candidate.finalFallback)
+      ) {
+        onReadyChange(false);
+        return;
+      }
+
+      let secondFrame = 0;
+      const firstFrame = requestAnimationFrame(() => {
+        secondFrame = requestAnimationFrame(() => onReadyChange(true));
+      });
+      return () => {
+        cancelAnimationFrame(firstFrame);
+        if (secondFrame) cancelAnimationFrame(secondFrame);
+      };
+    }, [
+      availableHeight,
+      candidate.finalFallback,
+      candidateIndex,
+      contentHeight,
+      onReadyChange,
+      overflows,
+      photoLoadsSettled,
+    ]);
+
+    const thumbnailSize = Math.max(
+      30,
+      Math.min(
+        58,
+        (frame.width - PHOTO_GAP * (MAX_SHARED_PHOTOS - 1)) / MAX_SHARED_PHOTOS,
+      ),
+    );
+    const fixedTextAlign = isRTL ? 'right' : 'left';
+    const finalBodyLineLimit = getFinalBodyLineLimit({ includeMood, includePhotos });
+
+    return (
+      <ShareCardFrame ref={ref} palette={palette} aspectRatio={output.aspectRatio}>
+        <View
+          // Remounting on a canvas change drops any layout event still queued
+          // for the previous, differently sized frame.
+          key={candidate.outputId}
+          style={{ flex: 1, overflow: 'hidden' }}
+          onLayout={(event) =>
+            setFrame({
+              width: event.nativeEvent.layout.width,
+              height: event.nativeEvent.layout.height,
+              aspectRatio: output.aspectRatio,
+            })
+          }>
+          <View
+            key={`${measurementToken}-${candidateIndex}`}
+            onLayout={(event) => setContentHeight(event.nativeEvent.layout.height)}
+            style={{ gap: candidate.contentGap }}>
+            <Text
+              allowFontScaling={false}
+              numberOfLines={1}
+              style={{
+                color: palette.foreground,
+                fontFamily: 'Figtree_700Bold',
+                fontSize: candidate.dateSize,
+                textAlign: fixedTextAlign,
+              }}>
+              {dateLabel}
+            </Text>
+
+            {includeMood && moodLabel && moodEmoji ? (
+              <View
+                style={{
+                  alignSelf: isRTL ? 'flex-end' : 'flex-start',
+                  flexDirection: isRTL ? 'row-reverse' : 'row',
+                  alignItems: 'center',
+                  gap: 6,
+                  borderRadius: 999,
+                  borderColor: palette.border,
+                  borderWidth: 1,
+                  backgroundColor: palette.accent,
+                  paddingHorizontal: 10,
+                  paddingVertical: 5,
+                }}>
+                <Text allowFontScaling={false} style={{ fontSize: 16 }}>
+                  {moodEmoji}
+                </Text>
+                <Text
+                  allowFontScaling={false}
+                  numberOfLines={1}
+                  style={{
+                    color: palette.foreground,
+                    fontFamily: 'Inter_600SemiBold',
+                    fontSize: 12,
+                    textAlign: fixedTextAlign,
+                  }}>
+                  {moodLabel}
+                </Text>
+              </View>
+            ) : null}
+
+            {title ? (
+              <Text
+                allowFontScaling={false}
+                numberOfLines={candidate.finalFallback ? 3 : undefined}
+                ellipsizeMode="tail"
+                style={{
+                  color: palette.foreground,
+                  fontFamily: 'Figtree_700Bold',
+                  fontSize: candidate.titleSize,
+                  lineHeight: candidate.titleSize + 5,
+                  textAlign: 'auto',
+                  writingDirection: 'auto',
+                }}>
+                {title.trim()}
+              </Text>
+            ) : null}
+
+            <View style={{ height: 2, backgroundColor: palette.border }} />
+
+            {body ? (
+              <Text
+                allowFontScaling={false}
+                numberOfLines={candidate.finalFallback ? finalBodyLineLimit : undefined}
+                ellipsizeMode="tail"
+                style={{
+                  color: palette.foreground,
+                  fontFamily: 'Inter_400Regular',
+                  fontSize: candidate.bodySize,
+                  lineHeight: candidate.lineHeight,
+                  textAlign: 'auto',
+                  writingDirection: 'auto',
+                }}>
+                {body.trim()}
+              </Text>
+            ) : null}
+
+            {includePhotos && visiblePhotos.length > 0 ? (
+              <View
+                style={{
+                  flexDirection: isRTL ? 'row-reverse' : 'row',
+                  gap: PHOTO_GAP,
+                  alignSelf: isRTL ? 'flex-end' : 'flex-start',
+                }}>
+                {visiblePhotos.map((photo) => (
+                  <Image
+                    key={photo.uri}
+                    source={{ uri: getFullPhotoUri(photo.uri) }}
+                    resizeMode="cover"
+                    onLoad={() =>
+                      setLoadedPhotos((current) => {
+                        const next = new Set(current);
+                        next.add(photo.uri);
+                        return next;
+                      })
+                    }
+                    onError={() =>
+                      setFailedPhotos((current) => {
+                        const next = new Set(current);
+                        next.add(photo.uri);
+                        return next;
+                      })
+                    }
+                    style={{
+                      width: thumbnailSize,
+                      height: thumbnailSize,
+                      borderRadius: 7,
+                      borderWidth: 1,
+                      borderColor: palette.border,
+                    }}
+                  />
+                ))}
+              </View>
+            ) : null}
+          </View>
+        </View>
+      </ShareCardFrame>
+    );
+  },
+);

--- a/apps/mobile/src/components/sharing/share-card-frame.tsx
+++ b/apps/mobile/src/components/sharing/share-card-frame.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { View, Text, type ViewStyle } from 'react-native';
+import { TackbokLogo } from '~/components/TackbokLogo';
+import type { SharePalette } from '~/lib/sharing/share-palettes';
+
+type ShareCardFrameProps = {
+  palette: SharePalette;
+  aspectRatio: number;
+  children: React.ReactNode;
+  onLayout?: React.ComponentProps<typeof View>['onLayout'];
+};
+
+export const ShareCardFrame = React.forwardRef<View, ShareCardFrameProps>(
+  function ShareCardFrame({ palette, aspectRatio, children, onLayout }, ref) {
+    const frameStyle: ViewStyle = {
+      width: '100%',
+      aspectRatio,
+      overflow: 'hidden',
+      backgroundColor: palette.background,
+      borderColor: palette.border,
+      borderWidth: 1,
+      paddingHorizontal: 24,
+      paddingTop: 24,
+      paddingBottom: 6,
+    };
+
+    return (
+      <View ref={ref} collapsable={false} onLayout={onLayout} style={frameStyle}>
+        <View style={{ flex: 1 }}>{children}</View>
+        <View
+          style={{
+            borderTopColor: palette.border,
+            borderTopWidth: 1,
+            paddingTop: 6,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 5,
+          }}>
+          <TackbokLogo size={15} color={palette.foreground} />
+          <Text
+            allowFontScaling={false}
+            style={{
+              color: palette.foreground,
+              fontFamily: 'Figtree_700Bold',
+              fontSize: 12,
+              letterSpacing: 0.5,
+            }}>
+            Tackbok
+          </Text>
+        </View>
+      </View>
+    );
+  },
+);

--- a/apps/mobile/src/components/sharing/share-palette-grid.tsx
+++ b/apps/mobile/src/components/sharing/share-palette-grid.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Pressable, View } from 'react-native';
+import { Check } from 'lucide-react-native';
+import { useTranslation } from '~/lib/i18n';
+import { SHARE_PALETTES, type SharePalette } from '~/lib/sharing/share-palettes';
+import type { ThemeId } from '~/lib/theme';
+import { TackbokLogo } from '~/components/TackbokLogo';
+import { Icon } from '~/components/ui/icon';
+
+type SharePaletteGridProps = {
+  selectedId: ThemeId;
+  onSelect: (palette: SharePalette) => void;
+};
+
+export function SharePaletteGrid({ selectedId, onSelect }: SharePaletteGridProps) {
+  const { t } = useTranslation();
+
+  return (
+    <View className="flex-row flex-wrap gap-3">
+      {SHARE_PALETTES.map((palette) => {
+        const selected = palette.id === selectedId;
+        return (
+          <Pressable
+            key={palette.id}
+            accessibilityRole="radio"
+            accessibilityState={{ selected }}
+            accessibilityLabel={
+              selected
+                ? t('{theme} theme, selected', { theme: palette.name })
+                : t('{theme} theme', { theme: palette.name })
+            }
+            onPress={() => onSelect(palette)}
+            className="relative w-[30.5%] aspect-square rounded-lg active:opacity-70"
+            style={{
+              backgroundColor: palette.background,
+              borderColor: selected ? palette.foreground : palette.border,
+              borderWidth: selected ? 4 : 1,
+            }}>
+            <View className="flex-1 items-center justify-center">
+              <TackbokLogo size={44} color={palette.foreground} />
+            </View>
+            {selected ? (
+              <View
+                className="absolute right-1.5 top-1.5 rounded-full p-0.5"
+                style={{ backgroundColor: palette.foreground }}>
+                <Icon
+                  as={Check}
+                  size={13}
+                  color={palette.background}
+                  className="size-3"
+                />
+              </View>
+            ) : null}
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/mobile/src/db/queries.ts
+++ b/apps/mobile/src/db/queries.ts
@@ -1,6 +1,7 @@
 import { desc, like, or, and, gte, lt, eq, sql } from 'drizzle-orm';
 import { startOfDay, format } from 'date-fns';
 import { generateUUID, sanitizePromptTitle, sanitizeTagName } from '~/lib/utils';
+import { getAchievementForCreateTransition, type Achievement } from '~/lib/achievements';
 import {
   db,
   entries,
@@ -38,21 +39,33 @@ export async function getAllEntriesGroupByDate(): Promise<Map<number, Entry[]>> 
 }
 
 /**
- * Get aggregate entry stats (total entries + distinct local-time days with at
- * least one entry). Used for bucketed analytics — only fetches timestamps.
+ * Total entries plus the distinct local-time day starts that contain one.
+ * Only fetches timestamps. Accepts a transaction so achievement evaluation and
+ * analytics can never disagree about where a day begins.
  */
-export async function getEntryStats(): Promise<{
-  entryCount: number;
-  daysWithEntries: number;
-}> {
-  const rows = await db.select({ created_at: entries.created_at }).from(entries);
+async function readEntryDays(
+  executor: Pick<typeof db, 'select'>,
+): Promise<{ entryCount: number; days: Set<number> }> {
+  const rows = await executor.select({ created_at: entries.created_at }).from(entries);
   // Day boundaries must match the app's timeline grouping (local time), so
   // dedupe in JS rather than with SQLite's UTC-based date().
   const days = new Set<number>();
   rows.forEach((row) => {
     days.add(startOfDay(new Date(row.created_at)).getTime());
   });
-  return { entryCount: rows.length, daysWithEntries: days.size };
+  return { entryCount: rows.length, days };
+}
+
+/**
+ * Get aggregate entry stats (total entries + distinct local-time days with at
+ * least one entry). Used for bucketed analytics.
+ */
+export async function getEntryStats(): Promise<{
+  entryCount: number;
+  daysWithEntries: number;
+}> {
+  const { entryCount, days } = await readEntryDays(db);
+  return { entryCount, daysWithEntries: days.size };
 }
 
 /**
@@ -239,6 +252,35 @@ export async function upsertEntry(entry: NewEntry) {
         created_at: entry.created_at ?? sql`${entries.created_at}`, // use previous value if new value is undefined
       },
     });
+}
+
+/**
+ * Inserts a genuine new entry and evaluates achievement eligibility from the
+ * same serialized database transition. Seeding, imports, and edits deliberately
+ * continue to use `upsertEntry` and therefore never enqueue celebrations.
+ */
+export async function createEntryWithAchievement(
+  entry: NewEntry,
+): Promise<Achievement | null> {
+  const now = Date.now();
+  const createdAt = entry.created_at ?? now;
+
+  return db.transaction(async (tx) => {
+    const { entryCount, days } = await readEntryDays(tx);
+
+    await tx.insert(entries).values({
+      ...entry,
+      created_at: createdAt,
+      updated_at: now,
+    });
+
+    return getAchievementForCreateTransition({
+      entryCountBefore: entryCount,
+      journaledDaysBefore: days.size,
+      // Local day starts, so this stays correct across DST transitions.
+      addsJournaledDay: !days.has(startOfDay(new Date(createdAt)).getTime()),
+    });
+  });
 }
 
 /**

--- a/apps/mobile/src/hooks/useGratitude.ts
+++ b/apps/mobile/src/hooks/useGratitude.ts
@@ -10,6 +10,7 @@ import {
   searchEntries,
   getAllTags,
   upsertEntry,
+  createEntryWithAchievement,
   getAllEntriesGroupByDate,
   updateTag,
   deleteTag,
@@ -158,6 +159,23 @@ export function useUpsertEntry() {
     mutationFn: (entry: NewEntry) => upsertEntry(entry),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.entries] });
+    },
+  });
+}
+
+/** Hook used only for user-created entries so passive writes cannot celebrate. */
+export function useCreateEntryWithAchievement() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (entry: NewEntry) => createEntryWithAchievement(entry),
+    onSuccess: (achievement) => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.entries] });
+      // Enqueued here rather than at the call site so any future create surface
+      // celebrates without having to remember this step.
+      if (achievement) {
+        useSettingsStore.getState().setPendingAchievement(achievement);
+      }
     },
   });
 }

--- a/apps/mobile/src/lib/achievement-dialog.ts
+++ b/apps/mobile/src/lib/achievement-dialog.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import type { Achievement } from '~/lib/achievements';
+
+interface AchievementDialogState {
+  manualAchievement: Achievement | null;
+  openManualAchievement: (achievement: Achievement) => void;
+  closeManualAchievement: () => void;
+}
+
+export const useAchievementDialogStore = create<AchievementDialogState>((set) => ({
+  manualAchievement: null,
+  openManualAchievement: (manualAchievement) => set({ manualAchievement }),
+  closeManualAchievement: () => set({ manualAchievement: null }),
+}));

--- a/apps/mobile/src/lib/achievements.test.ts
+++ b/apps/mobile/src/lib/achievements.test.ts
@@ -1,0 +1,70 @@
+import {
+  getAchievement,
+  getAchievementForCreateTransition,
+  isAchievementDay,
+} from './achievements';
+
+describe('achievement rules', () => {
+  test.each([1, 5, 10, 25, 50, 75])('recognizes %i as an achievement', (day) => {
+    expect(isAchievementDay(day)).toBe(true);
+    expect(getAchievement(day)).toEqual({
+      id: `journal-days-${day}`,
+      journaledDays: day,
+      variant: day === 1 ? 'first-day' : 'days',
+    });
+  });
+
+  test.each([-25, -1, 0, 2, 4, 6, 9, 11, 24, 26, 1.5])(
+    'rejects %s as an achievement',
+    (day) => {
+      expect(isAchievementDay(day)).toBe(false);
+      expect(getAchievement(day)).toBeNull();
+    },
+  );
+
+  test('day one requires an empty database', () => {
+    expect(
+      getAchievementForCreateTransition({
+        entryCountBefore: 0,
+        journaledDaysBefore: 0,
+        addsJournaledDay: true,
+      }),
+    ).toEqual(getAchievement(1));
+
+    expect(
+      getAchievementForCreateTransition({
+        entryCountBefore: 4,
+        journaledDaysBefore: 3,
+        addsJournaledDay: true,
+      }),
+    ).toBeNull();
+  });
+
+  test('only a newly added distinct day can earn later thresholds', () => {
+    expect(
+      getAchievementForCreateTransition({
+        entryCountBefore: 7,
+        journaledDaysBefore: 4,
+        addsJournaledDay: false,
+      }),
+    ).toBeNull();
+    expect(
+      getAchievementForCreateTransition({
+        entryCountBefore: 7,
+        journaledDaysBefore: 4,
+        addsJournaledDay: true,
+      }),
+    ).toEqual(getAchievement(5));
+  });
+
+  test('a recreated threshold is eligible from the live count', () => {
+    expect(
+      getAchievementForCreateTransition({
+        entryCountBefore: 30,
+        journaledDaysBefore: 24,
+        addsJournaledDay: true,
+      }),
+    ).toEqual(getAchievement(25));
+  });
+});
+

--- a/apps/mobile/src/lib/achievements.ts
+++ b/apps/mobile/src/lib/achievements.ts
@@ -1,0 +1,37 @@
+export type Achievement = {
+  id: `journal-days-${number}`;
+  journaledDays: number;
+  variant: 'first-day' | 'days';
+};
+
+export function isAchievementDay(dayCount: number): boolean {
+  return (
+    Number.isInteger(dayCount) &&
+    dayCount > 0 &&
+    (dayCount === 1 || dayCount === 5 || dayCount === 10 || dayCount % 25 === 0)
+  );
+}
+
+export function getAchievement(dayCount: number): Achievement | null {
+  if (!isAchievementDay(dayCount)) return null;
+
+  return {
+    id: `journal-days-${dayCount}`,
+    journaledDays: dayCount,
+    variant: dayCount === 1 ? 'first-day' : 'days',
+  };
+}
+
+export function getAchievementForCreateTransition({
+  entryCountBefore,
+  journaledDaysBefore,
+  addsJournaledDay,
+}: {
+  entryCountBefore: number;
+  journaledDaysBefore: number;
+  addsJournaledDay: boolean;
+}): Achievement | null {
+  if (entryCountBefore === 0) return getAchievement(1);
+  if (!addsJournaledDay) return null;
+  return getAchievement(journaledDaysBefore + 1);
+}

--- a/apps/mobile/src/lib/analytics/events.ts
+++ b/apps/mobile/src/lib/analytics/events.ts
@@ -29,6 +29,7 @@ export const SCREEN_ROUTE_MAP = {
   '/': 'home',
   '/gratitudeEntry': 'entry_new',
   '/gratitudeEntry/[noteId]': 'entry_view',
+  '/share-entry/[noteId]': 'entry_share',
   '/dateEntries/[dateMs]': 'date_entries',
   '/appearance': 'appearance',
   '/insights': 'insights',

--- a/apps/mobile/src/lib/i18n/translations/ar.ts
+++ b/apps/mobile/src/lib/i18n/translations/ar.ts
@@ -641,6 +641,30 @@ export const ar: Translations = {
   'Write a few entries and your stats will show up here.':
     'اكتب بعض الإدخالات وستظهر إحصاءاتك هنا.',
 
+  // المشاركة والإنجازات
+  'Share your gratitude': 'شارك امتنانك',
+  'I was grateful for': 'كنت ممتنًا لـ',
+  'Share image': 'مشاركة الصورة',
+  'Share entry': 'مشاركة الإدخال',
+  'Include mood': 'تضمين الحالة المزاجية',
+  'Mood is hidden unless you include it': 'تظل الحالة المزاجية مخفية ما لم تضمّنها',
+  'Include photos': 'تضمين الصور',
+  'Up to the first five photos will be shared': 'ستتم مشاركة أول خمس صور كحد أقصى',
+  'Choose a style': 'اختر نمطًا',
+  'Sharing is not available on this device': 'المشاركة غير متاحة على هذا الجهاز',
+  'Could not share image. Please try again.':
+    'تعذرت مشاركة الصورة. يرجى المحاولة مرة أخرى.',
+  '{theme} theme': 'سمة {theme}',
+  '{theme} theme, selected': 'سمة {theme}، محددة',
+  'Day one complete!': 'اكتمل اليوم الأول!',
+  'A beautiful beginning. Keep noticing the good.':
+    'بداية جميلة. واصل ملاحظة الأشياء الجيدة.',
+  '{count} days of gratitude!': '{count} يومًا من الامتنان!',
+  'Congratulations on making gratitude part of your journey.':
+    'تهانينا لجعل الامتنان جزءًا من رحلتك.',
+  'Share achievement': 'مشاركة الإنجاز',
+  'Open {count} day achievement': 'فتح إنجاز {count} يومًا',
+
   // Date Format Patterns (placeholders: {weekday}, {month}, {day}, {year})
   'dateFormat.short': '{day} {month} {year}',
   'dateFormat.full': '{weekday}، {day} {month} {year}',

--- a/apps/mobile/src/lib/i18n/translations/de.ts
+++ b/apps/mobile/src/lib/i18n/translations/de.ts
@@ -682,6 +682,33 @@ export const de: Translations = {
   'Write a few entries and your stats will show up here.':
     'Schreibe ein paar Einträge und deine Statistiken erscheinen hier.',
 
+  // Teilen und Erfolge
+  'Share your gratitude': 'Teile deine Dankbarkeit',
+  'I was grateful for': 'Ich war dankbar für',
+  'Share image': 'Bild teilen',
+  'Share entry': 'Eintrag teilen',
+  'Include mood': 'Stimmung einbeziehen',
+  'Mood is hidden unless you include it':
+    'Die Stimmung bleibt verborgen, wenn du sie nicht einbeziehst',
+  'Include photos': 'Fotos einbeziehen',
+  'Up to the first five photos will be shared':
+    'Bis zu den ersten fünf Fotos werden geteilt',
+  'Choose a style': 'Stil auswählen',
+  'Sharing is not available on this device':
+    'Teilen ist auf diesem Gerät nicht verfügbar',
+  'Could not share image. Please try again.':
+    'Das Bild konnte nicht geteilt werden. Bitte versuche es erneut.',
+  '{theme} theme': 'Design {theme}',
+  '{theme} theme, selected': 'Design {theme}, ausgewählt',
+  'Day one complete!': 'Tag eins geschafft!',
+  'A beautiful beginning. Keep noticing the good.':
+    'Ein schöner Anfang. Nimm weiterhin das Gute wahr.',
+  '{count} days of gratitude!': '{count} Tage Dankbarkeit!',
+  'Congratulations on making gratitude part of your journey.':
+    'Glückwunsch, dass Dankbarkeit Teil deines Weges ist.',
+  'Share achievement': 'Erfolg teilen',
+  'Open {count} day achievement': 'Erfolg für {count} Tage öffnen',
+
   // Date Format Patterns (placeholders: {weekday}, {month}, {day}, {year})
   'dateFormat.short': '{day}. {month} {year}',
   'dateFormat.full': '{weekday}, {day}. {month} {year}',

--- a/apps/mobile/src/lib/i18n/translations/en.ts
+++ b/apps/mobile/src/lib/i18n/translations/en.ts
@@ -657,6 +657,30 @@ export const en = {
   'Write a few entries and your stats will show up here.':
     'Write a few entries and your stats will show up here.',
 
+  // Sharing and achievements
+  'Share your gratitude': 'Share your gratitude',
+  'I was grateful for': 'I was grateful for',
+  'Share image': 'Share image',
+  'Share entry': 'Share entry',
+  'Include mood': 'Include mood',
+  'Mood is hidden unless you include it': 'Mood is hidden unless you include it',
+  'Include photos': 'Include photos',
+  'Up to the first five photos will be shared':
+    'Up to the first five photos will be shared',
+  'Choose a style': 'Choose a style',
+  'Sharing is not available on this device': 'Sharing is not available on this device',
+  'Could not share image. Please try again.': 'Could not share image. Please try again.',
+  '{theme} theme': '{theme} theme',
+  '{theme} theme, selected': '{theme} theme, selected',
+  'Day one complete!': 'Day one complete!',
+  'A beautiful beginning. Keep noticing the good.':
+    'A beautiful beginning. Keep noticing the good.',
+  '{count} days of gratitude!': '{count} days of gratitude!',
+  'Congratulations on making gratitude part of your journey.':
+    'Congratulations on making gratitude part of your journey.',
+  'Share achievement': 'Share achievement',
+  'Open {count} day achievement': 'Open {count} day achievement',
+
   // Date Format Patterns (placeholders: {weekday}, {month}, {day}, {year})
   'dateFormat.short': '{month} {day}, {year}',
   'dateFormat.full': '{weekday}, {month} {day}, {year}',

--- a/apps/mobile/src/lib/i18n/translations/he.ts
+++ b/apps/mobile/src/lib/i18n/translations/he.ts
@@ -640,6 +640,29 @@ export const he: Translations = {
   'Write a few entries and your stats will show up here.':
     'כתוב כמה רשומות והנתונים שלך יופיעו כאן.',
 
+  // שיתוף והישגים
+  'Share your gratitude': 'שיתוף הכרת התודה שלך',
+  'I was grateful for': 'הכרתי תודה על',
+  'Share image': 'שיתוף תמונה',
+  'Share entry': 'שיתוף רשומה',
+  'Include mood': 'הוספת מצב רוח',
+  'Mood is hidden unless you include it': 'מצב הרוח מוסתר אלא אם בוחרים להוסיף אותו',
+  'Include photos': 'הוספת תמונות',
+  'Up to the first five photos will be shared': 'ישותפו עד חמש התמונות הראשונות',
+  'Choose a style': 'בחירת סגנון',
+  'Sharing is not available on this device': 'השיתוף אינו זמין במכשיר הזה',
+  'Could not share image. Please try again.': 'לא ניתן לשתף את התמונה. נסו שוב.',
+  '{theme} theme': 'ערכת נושא {theme}',
+  '{theme} theme, selected': 'ערכת נושא {theme}, נבחרה',
+  'Day one complete!': 'היום הראשון הושלם!',
+  'A beautiful beginning. Keep noticing the good.':
+    'התחלה יפה. המשיכו להבחין בדברים הטובים.',
+  '{count} days of gratitude!': '{count} ימים של הכרת תודה!',
+  'Congratulations on making gratitude part of your journey.':
+    'כל הכבוד על הפיכת הכרת התודה לחלק מהדרך שלכם.',
+  'Share achievement': 'שיתוף הישג',
+  'Open {count} day achievement': 'פתיחת הישג של {count} ימים',
+
   // Date Format Patterns (placeholders: {weekday}, {month}, {day}, {year})
   'dateFormat.short': '{day} ב{month} {year}',
   'dateFormat.full': 'יום {weekday}, {day} ב{month} {year}',

--- a/apps/mobile/src/lib/i18n/translations/zh-CN.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-CN.ts
@@ -627,6 +627,28 @@ export const zhCN: Translations = {
   'Write a few entries and your stats will show up here.':
     '写下几条记录后，你的统计数据就会显示在这里。',
 
+  // 分享与成就
+  'Share your gratitude': '分享你的感恩',
+  'I was grateful for': '我感恩的是',
+  'Share image': '分享图片',
+  'Share entry': '分享记录',
+  'Include mood': '包含心情',
+  'Mood is hidden unless you include it': '除非你主动包含，否则心情不会显示',
+  'Include photos': '包含照片',
+  'Up to the first five photos will be shared': '最多分享前五张照片',
+  'Choose a style': '选择样式',
+  'Sharing is not available on this device': '此设备无法使用分享功能',
+  'Could not share image. Please try again.': '无法分享图片，请重试。',
+  '{theme} theme': '{theme}主题',
+  '{theme} theme, selected': '{theme}主题，已选择',
+  'Day one complete!': '第一天完成！',
+  'A beautiful beginning. Keep noticing the good.': '美好的开始。继续发现生活中的美好。',
+  '{count} days of gratitude!': '感恩第{count}天！',
+  'Congratulations on making gratitude part of your journey.':
+    '恭喜你让感恩成为人生旅程的一部分。',
+  'Share achievement': '分享成就',
+  'Open {count} day achievement': '打开第{count}天成就',
+
   // Date Format Patterns (placeholders: {weekday}, {month}, {day}, {year})
   'dateFormat.short': '{year}年{month}{day}日',
   'dateFormat.full': '{year}年{month}{day}日 {weekday}',

--- a/apps/mobile/src/lib/i18n/translations/zh-TW.ts
+++ b/apps/mobile/src/lib/i18n/translations/zh-TW.ts
@@ -629,6 +629,28 @@ export const zhTW: Translations = {
   'Write a few entries and your stats will show up here.':
     '寫下幾筆紀錄後，您的統計資料就會顯示在這裡。',
 
+  // 分享與成就
+  'Share your gratitude': '分享你的感恩',
+  'I was grateful for': '我感恩的是',
+  'Share image': '分享圖片',
+  'Share entry': '分享紀錄',
+  'Include mood': '包含心情',
+  'Mood is hidden unless you include it': '除非你主動包含，否則心情不會顯示',
+  'Include photos': '包含照片',
+  'Up to the first five photos will be shared': '最多分享前五張照片',
+  'Choose a style': '選擇樣式',
+  'Sharing is not available on this device': '此裝置無法使用分享功能',
+  'Could not share image. Please try again.': '無法分享圖片，請再試一次。',
+  '{theme} theme': '{theme}主題',
+  '{theme} theme, selected': '{theme}主題，已選取',
+  'Day one complete!': '第一天完成！',
+  'A beautiful beginning. Keep noticing the good.': '美好的開始。繼續發現生活中的美好。',
+  '{count} days of gratitude!': '感恩第{count}天！',
+  'Congratulations on making gratitude part of your journey.':
+    '恭喜你讓感恩成為人生旅程的一部分。',
+  'Share achievement': '分享成就',
+  'Open {count} day achievement': '開啟第{count}天成就',
+
   // Date Format Patterns (placeholders: {weekday}, {month}, {day}, {year})
   'dateFormat.short': '{year}年{month}{day}日',
   'dateFormat.full': '{year}年{month}{day}日 {weekday}',

--- a/apps/mobile/src/lib/settings/store.ts
+++ b/apps/mobile/src/lib/settings/store.ts
@@ -18,6 +18,7 @@ import {
   type BuiltInJournalPromptCategoryId,
   type JournalPromptsMode,
 } from '~/lib/journalPrompts';
+import type { Achievement } from '~/lib/achievements';
 
 // TODO: Implement actual functionality for all settings
 // This is currently a mock store - all values are stored but not yet connected to real features
@@ -72,6 +73,7 @@ interface SettingsState {
   /** Banner hidden without removing the entries — user chose to build over them. */
   sampleEntriesBannerDismissed: boolean;
   hasSeenHomeCoachMarks: boolean;
+  pendingAchievement: Achievement | null;
 
   // Hydration status
   _hasHydrated: boolean;
@@ -104,6 +106,7 @@ interface SettingsState {
   setSampleEntryIds: (ids: string[]) => void;
   setSampleEntriesBannerDismissed: (dismissed: boolean) => void;
   setHasSeenHomeCoachMarks: (seen: boolean) => void;
+  setPendingAchievement: (achievement: Achievement | null) => void;
   setHasHydrated: (hydrated: boolean) => void;
 }
 
@@ -133,6 +136,7 @@ const DEFAULT_SETTINGS_VALUES = {
   sampleEntryIds: [] as string[],
   sampleEntriesBannerDismissed: false,
   hasSeenHomeCoachMarks: false,
+  pendingAchievement: null,
 };
 
 export const useSettingsStore = create<SettingsState>()(
@@ -192,6 +196,8 @@ export const useSettingsStore = create<SettingsState>()(
       setSampleEntriesBannerDismissed: (dismissed) =>
         set({ sampleEntriesBannerDismissed: dismissed }),
       setHasSeenHomeCoachMarks: (seen) => set({ hasSeenHomeCoachMarks: seen }),
+      setPendingAchievement: (achievement) =>
+        set({ pendingAchievement: achievement }),
       setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),
     }),
     {
@@ -250,6 +256,7 @@ export const useSettingsStore = create<SettingsState>()(
         sampleEntryIds: state.sampleEntryIds,
         sampleEntriesBannerDismissed: state.sampleEntriesBannerDismissed,
         hasSeenHomeCoachMarks: state.hasSeenHomeCoachMarks,
+        pendingAchievement: state.pendingAchievement,
       }),
     },
   ),

--- a/apps/mobile/src/lib/sharing/share-image.test.ts
+++ b/apps/mobile/src/lib/sharing/share-image.test.ts
@@ -1,0 +1,139 @@
+import type React from 'react';
+import type { View } from 'react-native';
+import * as ExpoFileSystemMock from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+import { captureRef } from 'react-native-view-shot';
+import {
+  shareViewAsPng,
+  ShareNotReadyError,
+  SharingUnavailableError,
+} from './share-image';
+
+jest.mock('expo-file-system');
+jest.mock('expo-sharing', () => ({
+  isAvailableAsync: jest.fn(),
+  shareAsync: jest.fn(),
+}));
+jest.mock('react-native-view-shot', () => ({
+  captureRef: jest.fn(),
+}));
+
+const mockIsAvailable = Sharing.isAvailableAsync as jest.MockedFunction<
+  typeof Sharing.isAvailableAsync
+>;
+const mockShare = Sharing.shareAsync as jest.MockedFunction<typeof Sharing.shareAsync>;
+const mockCapture = captureRef as jest.MockedFunction<typeof captureRef>;
+const { __mockFileSystemState } = ExpoFileSystemMock as typeof ExpoFileSystemMock & {
+  __mockFileSystemState: {
+    createdFiles: {
+      uri: string;
+      exists: boolean;
+      copy: jest.Mock;
+      move: jest.Mock;
+    }[];
+    copyBehavior: (source: unknown, destination: unknown) => Promise<void>;
+    moveBehavior: (source: unknown, destination: unknown) => Promise<void>;
+  };
+};
+const viewRef = { current: {} as View } as React.RefObject<View>;
+
+const options = {
+  ref: viewRef,
+  dialogTitle: 'Share',
+  filenamePrefix: 'tackbok-test',
+  width: 1080,
+  height: 1350,
+  isReady: true,
+};
+
+describe('shareViewAsPng', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    __mockFileSystemState.createdFiles.length = 0;
+    __mockFileSystemState.copyBehavior = async () => {};
+    __mockFileSystemState.moveBehavior = async () => {};
+    mockIsAvailable.mockResolvedValue(true);
+    mockCapture.mockResolvedValue('/tmp/captured.png');
+    mockShare.mockResolvedValue();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('requires an explicitly ready capture target', async () => {
+    await expect(shareViewAsPng({ ...options, isReady: false })).rejects.toBeInstanceOf(
+      ShareNotReadyError,
+    );
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+
+  test('reports unavailable native sharing before capture', async () => {
+    mockIsAvailable.mockResolvedValue(false);
+    await expect(shareViewAsPng(options)).rejects.toBeInstanceOf(SharingUnavailableError);
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+
+  test('captures exact dimensions and shares a named PNG', async () => {
+    await expect(shareViewAsPng(options)).resolves.toBe('shared');
+    expect(mockCapture).toHaveBeenCalledWith(viewRef, {
+      format: 'png',
+      result: 'tmpfile',
+      width: 1080,
+      height: 1350,
+      quality: 1,
+    });
+    expect(mockShare).toHaveBeenCalledWith(
+      expect.stringMatching(/tackbok-test-\d+\.png$/),
+      { mimeType: 'image/png', UTI: 'public.png', dialogTitle: 'Share' },
+    );
+  });
+
+  test('runs presentation preparation after capture and before native sharing', async () => {
+    const beforePresentShareSheet = jest.fn(async () => {});
+
+    await expect(shareViewAsPng({ ...options, beforePresentShareSheet })).resolves.toBe(
+      'shared',
+    );
+
+    expect(mockCapture.mock.invocationCallOrder[0]).toBeLessThan(
+      beforePresentShareSheet.mock.invocationCallOrder[0],
+    );
+    expect(beforePresentShareSheet.mock.invocationCallOrder[0]).toBeLessThan(
+      mockShare.mock.invocationCallOrder[0],
+    );
+  });
+
+  test('renames the capture into place instead of copying its bytes', async () => {
+    await expect(shareViewAsPng(options)).resolves.toBe('shared');
+
+    const capturedFile = __mockFileSystemState.createdFiles[0]!;
+    expect(capturedFile.move).toHaveBeenCalledTimes(1);
+    expect(capturedFile.copy).not.toHaveBeenCalled();
+  });
+
+  test('rejects a re-entrant share while availability is pending', async () => {
+    let resolveAvailability!: (value: boolean) => void;
+    mockIsAvailable.mockImplementationOnce(
+      () => new Promise((resolve) => (resolveAvailability = resolve)),
+    );
+
+    const first = shareViewAsPng(options);
+    await expect(shareViewAsPng(options)).resolves.toBe('busy');
+    resolveAvailability(true);
+    await expect(first).resolves.toBe('shared');
+    expect(mockCapture).toHaveBeenCalledTimes(1);
+  });
+
+  test('deletes a named capture immediately when native sharing fails', async () => {
+    mockShare.mockRejectedValue(new Error('share failed'));
+    await expect(shareViewAsPng(options)).rejects.toThrow('share failed');
+
+    // The named destination is the last file constructed by the helper.
+    const namedFile = __mockFileSystemState.createdFiles.at(-1);
+    expect(namedFile?.uri).toMatch(/tackbok-test-\d+\.png$/);
+    expect(namedFile?.exists).toBe(false);
+  });
+});

--- a/apps/mobile/src/lib/sharing/share-image.ts
+++ b/apps/mobile/src/lib/sharing/share-image.ts
@@ -1,0 +1,90 @@
+import type React from 'react';
+import type { View } from 'react-native';
+import { File, Paths } from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+import { captureRef } from 'react-native-view-shot';
+
+let sharingInFlight = false;
+const CLEANUP_DELAY_MS = 60_000;
+
+export class SharingUnavailableError extends Error {}
+export class ShareNotReadyError extends Error {}
+
+export async function isNativeSharingAvailable(): Promise<boolean> {
+  return Sharing.isAvailableAsync();
+}
+
+type ShareViewAsPngOptions = {
+  ref: React.RefObject<View | null>;
+  dialogTitle: string;
+  filenamePrefix: string;
+  width: number;
+  height: number;
+  isReady: boolean;
+  beforePresentShareSheet?: () => Promise<void>;
+};
+
+export async function shareViewAsPng({
+  ref,
+  dialogTitle,
+  filenamePrefix,
+  width,
+  height,
+  isReady,
+  beforePresentShareSheet,
+}: ShareViewAsPngOptions): Promise<'shared' | 'busy'> {
+  if (sharingInFlight) return 'busy';
+  if (!isReady || !ref.current) throw new ShareNotReadyError();
+  sharingInFlight = true;
+  let capturedFile: File | null = null;
+  let namedFile: File | null = null;
+
+  try {
+    if (!(await Sharing.isAvailableAsync())) throw new SharingUnavailableError();
+
+    const capturedUri = await captureRef(ref, {
+      format: 'png',
+      result: 'tmpfile',
+      width,
+      height,
+      quality: 1,
+    });
+    capturedFile = new File(capturedUri);
+
+    // Both files live in app-local cache, so this is a rename rather than a
+    // multi-megabyte copy inside the user-visible tap-to-share-sheet latency.
+    const safePrefix = filenamePrefix.replace(/[^a-zA-Z0-9_-]/g, '-');
+    namedFile = new File(Paths.cache, `${safePrefix}-${Date.now()}.png`);
+    await capturedFile.move(namedFile);
+    capturedFile = null;
+
+    await beforePresentShareSheet?.();
+
+    await Sharing.shareAsync(namedFile.uri, {
+      mimeType: 'image/png',
+      UTI: 'public.png',
+      dialogTitle,
+    });
+
+    const cleanupFile = namedFile;
+    namedFile = null;
+    setTimeout(() => {
+      try {
+        if (cleanupFile.exists) cleanupFile.delete();
+      } catch {
+        // The OS cache remains the final cleanup fallback.
+      }
+    }, CLEANUP_DELAY_MS);
+    return 'shared';
+  } catch (error) {
+    try {
+      if (capturedFile?.exists) capturedFile.delete();
+      if (namedFile?.exists) namedFile.delete();
+    } catch {
+      // Best-effort cleanup only.
+    }
+    throw error;
+  } finally {
+    sharingInFlight = false;
+  }
+}

--- a/apps/mobile/src/lib/sharing/share-layouts.test.ts
+++ b/apps/mobile/src/lib/sharing/share-layouts.test.ts
@@ -20,6 +20,10 @@ describe('entry share layouts', () => {
       'tall',
     ]);
     expect(ENTRY_LAYOUT_CANDIDATES.at(-1)?.finalFallback).toBe(true);
+    // An early final fallback would stop the shrink cascade before it ran out.
+    expect(
+      ENTRY_LAYOUT_CANDIDATES.slice(0, -1).filter((candidate) => candidate.finalFallback),
+    ).toEqual([]);
   });
 
   test('exports exact standard dimensions', () => {

--- a/apps/mobile/src/lib/sharing/share-layouts.test.ts
+++ b/apps/mobile/src/lib/sharing/share-layouts.test.ts
@@ -1,0 +1,73 @@
+import {
+  ACHIEVEMENT_SHARE_OUTPUT,
+  ENTRY_LAYOUT_CANDIDATES,
+  FINAL_BODY_LINE_LIMITS,
+  getFinalBodyLineLimit,
+  SHARE_OUTPUTS,
+} from './share-layouts';
+
+describe('entry share layouts', () => {
+  test('progresses through fixed square, portrait, and tall candidates', () => {
+    expect(ENTRY_LAYOUT_CANDIDATES.map((candidate) => candidate.outputId)).toEqual([
+      'square',
+      'square',
+      'portrait',
+      'portrait',
+      'portrait',
+      'tall',
+      'tall',
+      'tall',
+      'tall',
+    ]);
+    expect(ENTRY_LAYOUT_CANDIDATES.at(-1)?.finalFallback).toBe(true);
+  });
+
+  test('exports exact standard dimensions', () => {
+    expect(SHARE_OUTPUTS.square).toMatchObject({ width: 1080, height: 1080 });
+    expect(SHARE_OUTPUTS.portrait).toMatchObject({ width: 1080, height: 1350 });
+    expect(SHARE_OUTPUTS.tall).toMatchObject({
+      width: 1080,
+      height: 1620,
+      aspectRatio: 2 / 3,
+    });
+  });
+
+  test('never grows text or spacing while stepping through candidates', () => {
+    ENTRY_LAYOUT_CANDIDATES.forEach((candidate, index) => {
+      const previous = ENTRY_LAYOUT_CANDIDATES[index - 1];
+      if (!previous || previous.outputId !== candidate.outputId) return;
+      expect(candidate.titleSize).toBeLessThan(previous.titleSize);
+      expect(candidate.bodySize).toBeLessThan(previous.bodySize);
+      expect(candidate.contentGap).toBeLessThanOrEqual(previous.contentGap);
+    });
+  });
+
+  test('reserves fewer body lines for the fallback as optional content is added', () => {
+    expect(getFinalBodyLineLimit({ includeMood: false, includePhotos: false })).toBe(
+      FINAL_BODY_LINE_LIMITS.textOnly,
+    );
+    expect(getFinalBodyLineLimit({ includeMood: true, includePhotos: false })).toBe(
+      FINAL_BODY_LINE_LIMITS.withMood,
+    );
+    expect(getFinalBodyLineLimit({ includeMood: false, includePhotos: true })).toBe(
+      FINAL_BODY_LINE_LIMITS.withPhotos,
+    );
+    // Photos are the taller region, so they win when both are included.
+    expect(getFinalBodyLineLimit({ includeMood: true, includePhotos: true })).toBe(
+      FINAL_BODY_LINE_LIMITS.withPhotos,
+    );
+    expect(FINAL_BODY_LINE_LIMITS.withPhotos).toBeLessThan(
+      FINAL_BODY_LINE_LIMITS.withMood,
+    );
+    expect(FINAL_BODY_LINE_LIMITS.withMood).toBeLessThan(FINAL_BODY_LINE_LIMITS.textOnly);
+  });
+
+  test('uses the 4:5 portrait preset for achievements', () => {
+    expect(ACHIEVEMENT_SHARE_OUTPUT).toBe(SHARE_OUTPUTS.portrait);
+    expect(ACHIEVEMENT_SHARE_OUTPUT).toMatchObject({
+      width: 1080,
+      height: 1350,
+      aspectRatio: 4 / 5,
+    });
+  });
+});

--- a/apps/mobile/src/lib/sharing/share-layouts.ts
+++ b/apps/mobile/src/lib/sharing/share-layouts.ts
@@ -1,0 +1,123 @@
+export const SHARE_OUTPUTS = {
+  square: { id: 'square', label: '1:1', width: 1080, height: 1080, aspectRatio: 1 },
+  portrait: {
+    id: 'portrait',
+    label: '4:5',
+    width: 1080,
+    height: 1350,
+    aspectRatio: 4 / 5,
+  },
+  tall: { id: 'tall', label: '2:3', width: 1080, height: 1620, aspectRatio: 2 / 3 },
+} as const;
+
+export type ShareOutputId = keyof typeof SHARE_OUTPUTS;
+export type ShareOutput = (typeof SHARE_OUTPUTS)[ShareOutputId];
+
+export const ACHIEVEMENT_SHARE_OUTPUT = SHARE_OUTPUTS.portrait;
+
+export type EntryLayoutCandidate = {
+  outputId: ShareOutputId;
+  titleSize: number;
+  bodySize: number;
+  dateSize: number;
+  lineHeight: number;
+  /** Vertical gap between the card's content rows at this text size. */
+  contentGap: number;
+  finalFallback?: boolean;
+};
+
+export const ENTRY_LAYOUT_CANDIDATES: readonly EntryLayoutCandidate[] = [
+  {
+    outputId: 'square',
+    titleSize: 25,
+    bodySize: 20,
+    dateSize: 18,
+    lineHeight: 28,
+    contentGap: 12,
+  },
+  {
+    outputId: 'square',
+    titleSize: 22,
+    bodySize: 17,
+    dateSize: 17,
+    lineHeight: 24,
+    contentGap: 12,
+  },
+  {
+    outputId: 'portrait',
+    titleSize: 25,
+    bodySize: 20,
+    dateSize: 18,
+    lineHeight: 28,
+    contentGap: 12,
+  },
+  {
+    outputId: 'portrait',
+    titleSize: 22,
+    bodySize: 17,
+    dateSize: 17,
+    lineHeight: 24,
+    contentGap: 12,
+  },
+  {
+    outputId: 'portrait',
+    titleSize: 19,
+    bodySize: 15,
+    dateSize: 16,
+    lineHeight: 21,
+    contentGap: 9,
+  },
+  {
+    outputId: 'tall',
+    titleSize: 25,
+    bodySize: 20,
+    dateSize: 18,
+    lineHeight: 28,
+    contentGap: 12,
+  },
+  {
+    outputId: 'tall',
+    titleSize: 22,
+    bodySize: 17,
+    dateSize: 17,
+    lineHeight: 24,
+    contentGap: 12,
+  },
+  {
+    outputId: 'tall',
+    titleSize: 19,
+    bodySize: 15,
+    dateSize: 16,
+    lineHeight: 21,
+    contentGap: 9,
+  },
+  {
+    outputId: 'tall',
+    titleSize: 17,
+    bodySize: 13,
+    dateSize: 15,
+    lineHeight: 18,
+    contentGap: 9,
+    finalFallback: true,
+  },
+] as const;
+
+/**
+ * Body line caps used only by the final fallback candidate, where tail ellipsis
+ * replaces further shrinking. Optional regions consume vertical space, so the
+ * body keeps fewer lines whenever they are included.
+ */
+export const FINAL_BODY_LINE_LIMITS = {
+  withPhotos: 10,
+  withMood: 14,
+  textOnly: 16,
+} as const;
+
+export function getFinalBodyLineLimit(options: {
+  includeMood: boolean;
+  includePhotos: boolean;
+}): number {
+  if (options.includePhotos) return FINAL_BODY_LINE_LIMITS.withPhotos;
+  if (options.includeMood) return FINAL_BODY_LINE_LIMITS.withMood;
+  return FINAL_BODY_LINE_LIMITS.textOnly;
+}

--- a/apps/mobile/src/lib/sharing/share-palettes.test.ts
+++ b/apps/mobile/src/lib/sharing/share-palettes.test.ts
@@ -1,0 +1,34 @@
+import { THEME_DEFINITIONS } from '~/lib/theme/theme-tokens';
+import { getSharePalette, SHARE_PALETTES, SHARE_THEME_IDS } from './share-palettes';
+
+describe('sharing palettes', () => {
+  test('uses the intentional initial theme order without duplicates', () => {
+    expect(SHARE_THEME_IDS).toEqual([
+      'light',
+      'dark',
+      'lavender',
+      'bubblegum',
+      'clemens',
+      'weckner',
+      'hecker',
+      'peach',
+      'ember',
+    ]);
+    expect(new Set(SHARE_THEME_IDS).size).toBe(SHARE_THEME_IDS.length);
+  });
+
+  test.each(SHARE_THEME_IDS)('projects %s directly from theme tokens', (id) => {
+    const definition = THEME_DEFINITIONS.find((theme) => theme.id === id)!;
+    const palette = SHARE_PALETTES.find((candidate) => candidate.id === id)!;
+    expect(palette).toMatchObject({
+      background: definition.tokens['--color-background'],
+      foreground: definition.tokens['--color-foreground'],
+      border: definition.tokens['--color-border'],
+      accent: definition.tokens['--color-accent'],
+    });
+  });
+
+  test('achievement cards can project an active theme outside the entry grid', () => {
+    expect(getSharePalette('ocean').id).toBe('ocean');
+  });
+});

--- a/apps/mobile/src/lib/sharing/share-palettes.ts
+++ b/apps/mobile/src/lib/sharing/share-palettes.ts
@@ -42,13 +42,18 @@ export function getSharePalette(id: string): SharePalette {
   };
 }
 
-export const SHARE_PALETTES: readonly SharePalette[] = SHARE_THEME_IDS.map((id) => {
-  const palette = getSharePalette(id);
-  // The Light fallback must never turn a mistyped grid member into a silent
-  // duplicate tile.
-  if (palette.id !== id) throw new Error(`Unknown sharing theme: ${id}`);
-  return palette;
-});
+export const SHARE_PALETTES: readonly SharePalette[] = (() => {
+  const seen = new Set<string>();
+  return SHARE_THEME_IDS.map((id) => {
+    const palette = getSharePalette(id);
+    // Neither a mistyped grid member falling back to Light nor a repeated id
+    // may turn into a silent duplicate tile.
+    if (palette.id !== id) throw new Error(`Unknown sharing theme: ${id}`);
+    if (seen.has(id)) throw new Error(`Duplicate sharing theme: ${id}`);
+    seen.add(id);
+    return palette;
+  });
+})();
 
 export function isShareThemeId(value: string): value is ShareThemeId {
   return SHARE_THEME_IDS.some((id) => id === value);

--- a/apps/mobile/src/lib/sharing/share-palettes.ts
+++ b/apps/mobile/src/lib/sharing/share-palettes.ts
@@ -1,0 +1,55 @@
+import { getThemeDefinition } from '~/lib/theme/theme-tokens';
+import { getThemeConfig, type ThemeId } from '~/lib/theme';
+
+export const SHARE_THEME_IDS = [
+  'light',
+  'dark',
+  'lavender',
+  'bubblegum',
+  'clemens',
+  'weckner',
+  'hecker',
+  'peach',
+  'ember',
+] as const satisfies readonly ThemeId[];
+
+export type ShareThemeId = (typeof SHARE_THEME_IDS)[number];
+
+export type SharePalette = {
+  id: ThemeId;
+  name: string;
+  background: string;
+  foreground: string;
+  border: string;
+  accent: string;
+};
+
+/**
+ * Projects a theme's tokens onto a share card. Any app theme can be projected —
+ * the achievement card follows the active theme, which may sit outside the
+ * entry composer's grid. The persisted theme id is a plain string, so unknown
+ * or removed ids resolve to the default Light theme.
+ */
+export function getSharePalette(id: string): SharePalette {
+  const theme = getThemeDefinition(getThemeConfig(id).id);
+  return {
+    id: theme.id,
+    name: theme.name,
+    background: theme.tokens['--color-background'],
+    foreground: theme.tokens['--color-foreground'],
+    border: theme.tokens['--color-border'],
+    accent: theme.tokens['--color-accent'],
+  };
+}
+
+export const SHARE_PALETTES: readonly SharePalette[] = SHARE_THEME_IDS.map((id) => {
+  const palette = getSharePalette(id);
+  // The Light fallback must never turn a mistyped grid member into a silent
+  // duplicate tile.
+  if (palette.id !== id) throw new Error(`Unknown sharing theme: ${id}`);
+  return palette;
+});
+
+export function isShareThemeId(value: string): value is ShareThemeId {
+  return SHARE_THEME_IDS.some((id) => id === value);
+}

--- a/apps/mobile/src/lib/sharing/use-share-image.ts
+++ b/apps/mobile/src/lib/sharing/use-share-image.ts
@@ -1,0 +1,87 @@
+import React from 'react';
+import type { View } from 'react-native';
+import { useTranslation } from '~/lib/i18n';
+import { toast } from '~/components/ui/toast';
+import {
+  isNativeSharingAvailable,
+  shareViewAsPng,
+  SharingUnavailableError,
+} from './share-image';
+
+export type ShareResult = 'shared' | 'busy' | 'unavailable' | 'failed';
+
+type ShareRequest = {
+  ref: React.RefObject<View | null>;
+  dialogTitle: string;
+  filenamePrefix: string;
+  width: number;
+  height: number;
+  isReady: boolean;
+  beforePresentShareSheet?: () => Promise<void>;
+  /** Content-free console label; never pass entry text, ids, or file paths. */
+  logLabel: string;
+};
+
+/**
+ * Owns everything both share surfaces need around `shareViewAsPng`: the native
+ * availability probe, the busy flag, and localized error reporting. Keeping it
+ * in one place stops the achievement dialog and the entry composer from
+ * drifting apart on guards and error handling.
+ */
+export function useShareImage({ enabled = true }: { enabled?: boolean } = {}) {
+  const { t } = useTranslation();
+  const mountedRef = React.useRef(true);
+  const [isSharing, setIsSharing] = React.useState(false);
+  const [isAvailable, setIsAvailable] = React.useState<boolean | null>(null);
+
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!enabled) return;
+    let active = true;
+    void isNativeSharingAvailable()
+      .then((available) => {
+        if (active) setIsAvailable(available);
+      })
+      .catch(() => {
+        if (active) setIsAvailable(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [enabled]);
+
+  const share = React.useCallback(
+    async ({ logLabel, ...options }: ShareRequest): Promise<ShareResult> => {
+      if (isSharing) return 'busy';
+      if (isAvailable === false) {
+        toast.error(t('Sharing is not available on this device'));
+        return 'unavailable';
+      }
+
+      setIsSharing(true);
+      try {
+        return await shareViewAsPng(options);
+      } catch (error) {
+        if (error instanceof SharingUnavailableError) {
+          if (mountedRef.current) setIsAvailable(false);
+          toast.error(t('Sharing is not available on this device'));
+          return 'unavailable';
+        }
+        console.error(logLabel);
+        toast.error(t('Could not share image. Please try again.'));
+        return 'failed';
+      } finally {
+        if (mountedRef.current) setIsSharing(false);
+      }
+    },
+    [isAvailable, isSharing, t],
+  );
+
+  return { isAvailable, isSharing, share };
+}

--- a/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryEdit.tsx
+++ b/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryEdit.tsx
@@ -29,7 +29,12 @@ import { useTranslation, formatLocalizedDate, formatTimeLabel } from '~/lib/i18n
 import { generateUUID } from '~/lib/utils';
 import { filterExistingPhotos } from '~/lib/photoUtils';
 import { filterExistingVoiceMemos } from '~/lib/voiceMemoUtils';
-import { useCustomPrompts, useUpsertEntry, useTagMapping } from '~/hooks/useGratitude';
+import {
+  useCreateEntryWithAchievement,
+  useCustomPrompts,
+  useUpsertEntry,
+  useTagMapping,
+} from '~/hooks/useGratitude';
 import { usePhotoSession } from '~/hooks/usePhotoSession';
 import { useVoiceMemoSession } from '~/hooks/useVoiceMemoSession';
 import { useWorksheetTemplate } from '~/hooks/useWorksheetTemplate';
@@ -138,6 +143,7 @@ function GratitudeEntryEditForm({
 
   // Mutations
   const upsertEntryMutation = useUpsertEntry();
+  const createEntryMutation = useCreateEntryWithAchievement();
   const isSaving = useRef(false);
 
   // Keyboard animation for floating dock positioning (avoids iOS touch issues with KeyboardStickyView)
@@ -307,6 +313,9 @@ function GratitudeEntryEditForm({
 
   const handleSave = async () => {
     if (!canSave) return;
+    // A second tap before the write settles would generate a fresh UUID and
+    // store the entry twice.
+    if (isSaving.current) return;
 
     isSaving.current = true;
     const id = initialEntry?.note_id || generateUUID();
@@ -315,7 +324,7 @@ function GratitudeEntryEditForm({
     const allAssets: Asset[] = [...photos, ...voiceMemos];
 
     try {
-      await upsertEntryMutation.mutateAsync({
+      const entryToSave = {
         note_id: id,
         text_title: title.trim() || null,
         text_content: content.trim() || null,
@@ -324,7 +333,14 @@ function GratitudeEntryEditForm({
         tags: selectedTagIds.join(','),
         created_at: timestamp,
         updated_at: Date.now(),
-      });
+      };
+      // The create path also evaluates and enqueues achievements; edits and
+      // other passive writes must keep using the plain upsert.
+      if (isNewEntry) {
+        await createEntryMutation.mutateAsync(entryToSave);
+      } else {
+        await upsertEntryMutation.mutateAsync(entryToSave);
+      }
 
       // Delete files that were removed during this editing session.
       // Best-effort: runs only after a successful save to prevent data loss

--- a/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryView.tsx
+++ b/apps/mobile/src/screens/gratitudeEntry/GratitudeEntryView.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { View, ScrollView } from 'react-native';
-import { ArrowLeft, ArrowRight, Pencil, Trash2 } from 'lucide-react-native';
+import { ArrowLeft, ArrowRight, Pencil, Share2, Trash2 } from 'lucide-react-native';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MOOD_OPTIONS, MODAL_CLOSE_DELAY } from '~/constants';
 import type { Entry, Asset } from '~/types';
 import { filterExistingPhotos } from '~/lib/photoUtils';
@@ -39,6 +41,8 @@ export function GratitudeEntryView({
   onPhotoPress,
 }: GratitudeEntryViewProps) {
   const { t, isRTL } = useTranslation();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
   const tagMap = useTagMapping();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const deleteEntryMutation = useDeleteEntry();
@@ -71,6 +75,7 @@ export function GratitudeEntryView({
 
   // Extract voice memo assets (only those whose files still exist on disk)
   const voiceMemos = filterExistingVoiceMemos(entry.assets ?? null);
+  const canShare = Boolean(title?.trim() || content?.trim());
 
   const handleDelete = async () => {
     try {
@@ -178,6 +183,23 @@ export function GratitudeEntryView({
           </View>
         )}
       </ScrollView>
+
+      {canShare ? (
+        <Button
+          variant="outline"
+          size="icon"
+          className="absolute left-4 h-12 w-12 rounded-full bg-background shadow-theme"
+          style={{ bottom: Math.max(insets.bottom, 12) }}
+          accessibilityLabel={t('Share entry')}
+          onPress={() =>
+            router.push({
+              pathname: '/share-entry/[noteId]',
+              params: { noteId: entry.note_id },
+            })
+          }>
+          <Icon as={Share2} size={21} />
+        </Button>
+      ) : null}
 
       <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <AlertDialogContent>

--- a/apps/mobile/src/screens/home/GratitudeMilestone.tsx
+++ b/apps/mobile/src/screens/home/GratitudeMilestone.tsx
@@ -3,28 +3,41 @@ import { View, Pressable } from 'react-native';
 import { cn } from 'tailwind-variants';
 import { useCSSVariable } from 'uniwind';
 import { type MilestoneItem } from '~/types';
-import { useTranslation } from '~/lib/i18n';
+import { formatLocalizedNumber, useTranslation } from '~/lib/i18n';
 import { useSettingsStore } from '~/lib/settings';
 import { Text } from '~/components/ui/text';
 import { TackbokLogo } from '~/components/TackbokLogo';
+import { getAchievement, isAchievementDay } from '~/lib/achievements';
+import { useAchievementDialogStore } from '~/lib/achievement-dialog';
 
 interface IGratitudeMilestoneProps {
   milestone: MilestoneItem;
 }
 
 export const GratitudeMilestone: React.FC<IGratitudeMilestoneProps> = ({ milestone }) => {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const showTimelineBorders = useSettingsStore((state) => state.showTimelineBorders);
   const [foregroundColor] = useCSSVariable(['--color-foreground']);
 
   const handlePress = () => {
-    // TODO: Implement Share Milestone functionality
-    console.log('Milestone pressed', milestone);
+    const achievement = getAchievement(milestone.milestoneDays);
+    if (achievement) {
+      useAchievementDialogStore.getState().openManualAchievement(achievement);
+    }
   };
 
   return (
     <Pressable
       onPress={handlePress}
+      disabled={milestone.milestoneDays === 0}
+      accessibilityRole={milestone.milestoneDays === 0 ? undefined : 'button'}
+      accessibilityLabel={
+        milestone.milestoneDays === 0
+          ? undefined
+          : t('Open {count} day achievement', {
+              count: formatLocalizedNumber(milestone.milestoneDays, locale),
+            })
+      }
       className={cn(
         'flex-row w-full active:bg-muted',
         showTimelineBorders && !milestone.isLast && 'border-b-2 border-border',
@@ -74,5 +87,5 @@ export const GratitudeMilestone: React.FC<IGratitudeMilestoneProps> = ({ milesto
 // Helper function to check if a day count is a milestone
 // Milestones: 5, 10, and every multiple of 25 (25, 50, 75, 100, ...)
 export function isMilestone(dayCount: number): boolean {
-  return dayCount === 0 || dayCount === 5 || dayCount === 10 || dayCount % 25 === 0;
+  return dayCount === 0 || (dayCount !== 1 && isAchievementDay(dayCount));
 }

--- a/apps/mobile/src/screens/home/GratitudeTimeline.tsx
+++ b/apps/mobile/src/screens/home/GratitudeTimeline.tsx
@@ -115,12 +115,9 @@ export const GratitudeTimeline: React.FC<IGratitudeTimelineProps> = ({
     let processedDays = 0;
 
     finalDayGroups.forEach((group) => {
-      // Placeholders have an empty entries array, so hasContent is false.
-      // For real entries, check that at least one has substantive data.
-      const hasContent = group.entries.some(
-        (e) =>
-          e.text_content || e.text_title || e.mood || (e.assets && e.assets.length > 0),
-      );
+      // Every stored entry day counts, including seeded/imported entries. Only
+      // synthetic today/yesterday placeholders have no entries.
+      const hasContent = group.entries.length > 0;
 
       const remainingDays = totalContentDays - processedDays;
 

--- a/apps/mobile/src/screens/sharing/entry-share-screen.tsx
+++ b/apps/mobile/src/screens/sharing/entry-share-screen.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { ArrowLeft, ArrowRight, Check } from 'lucide-react-native';
+import { useEntry } from '~/hooks/useGratitude';
+import { MOOD_OPTIONS } from '~/constants';
+import { filterExistingPhotos } from '~/lib/photoUtils';
+import { formatLocalizedDate, useTranslation } from '~/lib/i18n';
+import { useSettingsStore } from '~/lib/settings';
+import {
+  getSharePalette,
+  isShareThemeId,
+  type SharePalette,
+} from '~/lib/sharing/share-palettes';
+import { SHARE_OUTPUTS, type ShareOutput } from '~/lib/sharing/share-layouts';
+import { useShareImage } from '~/lib/sharing/use-share-image';
+import { SafeAreaView } from '~/components/ui/safe-area-view';
+import { Button } from '~/components/ui/button';
+import { Icon } from '~/components/ui/icon';
+import { Switch } from '~/components/ui/switch';
+import { Text } from '~/components/ui/text';
+import { ThemeBackdrop } from '~/components/backdrops/ThemeBackdrop';
+import { EntryShareCard } from '~/components/sharing/entry-share-card';
+import { SharePaletteGrid } from '~/components/sharing/share-palette-grid';
+
+export function EntryShareScreen({ noteId }: { noteId?: string }) {
+  const router = useRouter();
+  const { t, isRTL } = useTranslation();
+  const activeTheme = useSettingsStore((state) => state.theme);
+  const { data: entry, isLoading, isError, refetch } = useEntry(noteId);
+  const captureRef = React.useRef<View>(null);
+  const [includeMood, setIncludeMood] = React.useState(false);
+  const [includePhotos, setIncludePhotos] = React.useState(false);
+  const [captureReady, setCaptureReady] = React.useState(false);
+  const [output, setOutput] = React.useState<ShareOutput>(SHARE_OUTPUTS.square);
+  const [palette, setPalette] = React.useState<SharePalette>(() =>
+    getSharePalette(isShareThemeId(activeTheme) ? activeTheme : 'light'),
+  );
+  const { isAvailable: sharingAvailable, isSharing, share } = useShareImage();
+
+  useFocusEffect(
+    React.useCallback(() => {
+      // Navigation may keep a previous composer mounted in the stack. Reset
+      // sensitive inclusion choices on every focus, not just first mount.
+      // Capture readiness belongs to the card — it re-reports whenever these
+      // switches change what has to be measured.
+      setIncludeMood(false);
+      setIncludePhotos(false);
+    }, []),
+  );
+
+  const handleReadyChange = React.useCallback((ready: boolean) => {
+    setCaptureReady(ready);
+  }, []);
+  const handleOutputChange = React.useCallback((next: ShareOutput) => {
+    setOutput(next);
+  }, []);
+
+  // The card enforces its own five-photo cap; this list only decides whether the
+  // "Include photos" switch is offered at all.
+  const photos = React.useMemo(
+    () => filterExistingPhotos(entry?.assets ?? null),
+    [entry?.assets],
+  );
+  const moodOption = entry?.mood
+    ? MOOD_OPTIONS.find((option) => option.value === entry.mood)
+    : null;
+
+  const handleShare = React.useCallback(async () => {
+    if (!entry) return;
+    await share({
+      ref: captureRef,
+      dialogTitle: t('Share your gratitude'),
+      filenamePrefix: 'tackbok-gratitude',
+      width: output.width,
+      height: output.height,
+      isReady: captureReady,
+      logLabel: 'Entry image sharing failed',
+    });
+  }, [captureReady, entry, output.height, output.width, share, t]);
+
+  return (
+    <SafeAreaView className="flex-1 bg-background" edges={['top', 'left', 'right']}>
+      <ThemeBackdrop />
+      <View className="flex-row items-center border-b border-border px-4 py-2">
+        <View className="w-12">
+          <Button
+            variant="ghost"
+            size="icon"
+            accessibilityLabel={t('Back')}
+            onPress={() => router.back()}>
+            <Icon as={isRTL ? ArrowRight : ArrowLeft} />
+          </Button>
+        </View>
+        <Text className="flex-1 text-center text-lg font-body-bold text-foreground">
+          {t('Share your gratitude')}
+        </Text>
+        <View className="w-12 items-end">
+          <Button
+            variant="ghost"
+            size="icon"
+            disabled={!entry || !captureReady || isSharing || sharingAvailable !== true}
+            accessibilityLabel={t('Share image')}
+            onPress={() => void handleShare()}>
+            {isSharing ? <ActivityIndicator size="small" /> : <Icon as={Check} />}
+          </Button>
+        </View>
+      </View>
+
+      {isLoading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="large" />
+        </View>
+      ) : isError ? (
+        <View className="flex-1 items-center justify-center gap-4 px-8">
+          <Text className="text-center text-muted-foreground">{t('Unknown error')}</Text>
+          <Button onPress={() => refetch()}>
+            <Text>{t('Retry')}</Text>
+          </Button>
+        </View>
+      ) : !entry ? (
+        <View className="flex-1 items-center justify-center gap-4 px-8">
+          <Text className="text-center text-muted-foreground">
+            {t('Entry not found')}
+          </Text>
+          <Button variant="outline" onPress={() => router.back()}>
+            <Text>{t('Back')}</Text>
+          </Button>
+        </View>
+      ) : (
+        <ScrollView
+          className="flex-1"
+          contentInsetAdjustmentBehavior="automatic"
+          contentContainerClassName="gap-5 px-4 pt-4 pb-safe-or-12">
+          <EntryShareCard
+            ref={captureRef}
+            dateLabel={formatLocalizedDate(entry.created_at, t, { relative: true })}
+            title={entry.text_title?.trim() || t('I was grateful for')}
+            body={entry.text_content}
+            moodLabel={moodOption ? t(`Feeling ${moodOption.label}`) : null}
+            moodEmoji={moodOption?.emoji}
+            photos={photos}
+            includeMood={includeMood}
+            includePhotos={includePhotos}
+            isRTL={isRTL}
+            palette={palette}
+            onReadyChange={handleReadyChange}
+            onOutputChange={handleOutputChange}
+          />
+
+          <View className="self-center rounded-full border border-border bg-card px-3 py-1">
+            <Text className="text-xs text-muted-foreground">{output.label}</Text>
+          </View>
+
+          {entry.mood && moodOption ? (
+            <View className="flex-row items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-3">
+              <View className="flex-1 gap-1">
+                <Text className="font-body-semibold text-foreground">
+                  {t('Include mood')}
+                </Text>
+                <Text className="text-sm text-muted-foreground">
+                  {t('Mood is hidden unless you include it')}
+                </Text>
+              </View>
+              <Switch
+                checked={includeMood}
+                onCheckedChange={setIncludeMood}
+                accessibilityLabel={t('Include mood')}
+              />
+            </View>
+          ) : null}
+
+          {photos.length > 0 ? (
+            <View className="flex-row items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-3">
+              <View className="flex-1 gap-1">
+                <Text className="font-body-semibold text-foreground">
+                  {t('Include photos')}
+                </Text>
+                <Text className="text-sm text-muted-foreground">
+                  {t('Up to the first five photos will be shared')}
+                </Text>
+              </View>
+              <Switch
+                checked={includePhotos}
+                onCheckedChange={setIncludePhotos}
+                accessibilityLabel={t('Include photos')}
+              />
+            </View>
+          ) : null}
+
+          <View className="gap-3">
+            <Text className="text-lg font-body-bold text-foreground">
+              {t('Choose a style')}
+            </Text>
+            <SharePaletteGrid selectedId={palette.id} onSelect={setPalette} />
+          </View>
+
+          {sharingAvailable === false ? (
+            <Text className="text-center text-sm text-destructive">
+              {t('Sharing is not available on this device')}
+            </Text>
+          ) : null}
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "apps/mobile": {
       "name": "@tackbok/mobile",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
         "@expo-google-fonts/baskervville": "^0.4.1",
@@ -63,6 +63,7 @@
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "~4.26.2",
         "react-native-svg": "15.15.4",
+        "react-native-view-shot": "^5.1.1",
         "react-native-worklets": "0.10.0",
         "tailwind-variants": "^3.2.2",
         "tailwindcss": "^4.3.0",
@@ -1202,6 +1203,8 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "base64-arraybuffer": ["base64-arraybuffer@1.0.2", "", {}, "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="],
+
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.30", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg=="],
@@ -1317,6 +1320,8 @@
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
+
+    "css-line-break": ["css-line-break@2.1.0", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
@@ -1749,6 +1754,8 @@
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -2330,6 +2337,8 @@
 
     "react-native-svg": ["react-native-svg@15.15.4", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A=="],
 
+    "react-native-view-shot": ["react-native-view-shot@5.1.1", "", { "dependencies": { "html2canvas": "^1.4.1" }, "peerDependencies": { "react": ">=18.0.0", "react-native": ">=0.76.0" } }, "sha512-jOTLQrMGNBgv/nRA81VR2x2AdiCGoCjc63c9a5P4A0gStCbh9oDeJ6W+GtRxxQmxXXf6LDSrvG+mmWYulIrOkg=="],
+
     "react-native-worklets": ["react-native-worklets@0.10.0", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.27.1", "@babel/plugin-transform-class-properties": "^7.28.6", "@babel/plugin-transform-classes": "^7.28.6", "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6", "@babel/plugin-transform-optional-chaining": "^7.28.6", "@babel/plugin-transform-shorthand-properties": "^7.27.1", "@babel/plugin-transform-template-literals": "^7.27.1", "@babel/plugin-transform-unicode-regex": "^7.27.1", "@babel/preset-typescript": "^7.28.5", "@babel/types": "^7.27.1", "convert-source-map": "^2.0.0", "semver": "^7.7.4" }, "peerDependencies": { "@babel/core": "*", "@react-native/metro-config": "*", "react": "*", "react-native": "0.83 - 0.86" } }, "sha512-JhE6IxDf6iabC0qu3+TAKA4v9RlluXmoIngPQX7/QUByf75lfrsHZ6/dQhyjEWnp1EEQiwzz8Cpew140ZcewDw=="],
 
     "react-reconciler": ["react-reconciler@0.31.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ=="],
@@ -2578,6 +2587,8 @@
 
     "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
 
+    "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
+
     "throat": ["throat@5.0.0", "", {}, "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="],
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
@@ -2703,6 +2714,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
     "uuid": ["uuid@7.0.3", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="],
 


### PR DESCRIPTION
- Celebrate journaling milestones (day 1, 5, 10, every 25th distinct day) with an automatic dialog after a genuine new-entry save, backed by a serialized create-and-count transaction. Timeline milestones reopen the same dialog manually; pending celebrations persist across restarts and reset with Delete All Data.
- Share a gratitude entry as a branded PNG from a new composer screen with nine theme palettes, session-only mood/photo inclusion switches, and measured aspect/font fitting across 1:1, 4:5, and 2:3 canvases.

Shared capture pipeline (react-native-view-shot + expo-sharing) with single-flight guard, iOS overlay handoff, and temp-file cleanup. Localized in all six languages; no journal content in analytics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share gratitude entries as customizable images with selectable themes, layouts, photos, and moods.
  * Added native image sharing with readiness checks and helpful error feedback.
  * Added achievement milestones for journal progress, including celebratory dialogs and shareable achievement cards.
  * Added localized sharing and achievement content across supported languages.
* **Bug Fixes**
  * Improved timeline content detection for imported and seeded entries.
  * Prevented duplicate entry saves while a save is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->